### PR TITLE
Add tests for 'closed' annotations

### DIFF
--- a/constraints/annotations/closed.isl
+++ b/constraints/annotations/closed.isl
@@ -1,0 +1,22 @@
+type::{
+    annotations: closed::[a, b, c, d],
+}
+valid::[
+    5,
+    a::5,
+    b::5,
+    c::5,
+    d::5,
+    a::a::a::5,
+    a::b::c::d::5,
+    b::a::d::c::5,
+    d::c::b::a::5,
+    d::d::c::c::b::b::a::a::5,
+]
+invalid::[
+    open_content::a::open_content::b::open_content::c::open_content::d::open_content::5,
+    e::5,
+    abcd::5,
+    a::b::c::d::e::5,
+]
+

--- a/constraints/annotations/closed_any_annotations.isl
+++ b/constraints/annotations/closed_any_annotations.isl
@@ -1,0 +1,10 @@
+type::{
+  not: { annotations: closed::[] },
+}
+valid::[
+  a::5,
+]
+invalid::[
+  5,
+]
+

--- a/constraints/annotations/closed_mixed.isl
+++ b/constraints/annotations/closed_mixed.isl
@@ -1,0 +1,22 @@
+type::{
+    annotations: closed::required::[a, b, optional::c],
+}
+valid::[
+    a::b::5,
+    b::a::5,
+    a::b::c::5,
+    a::c::b::5,
+    b::c::a::5,
+    c::a::b::5,
+    a::a::b::c::5,
+    a::b::c::c::b::a::5,
+]
+invalid::[
+    5,
+    a::5,
+    b::5,
+    a::c::5,
+    b::c::5,
+    a::b::d::5,
+    a::b::c::d::5,
+]

--- a/constraints/annotations/closed_no_annotations.isl
+++ b/constraints/annotations/closed_no_annotations.isl
@@ -1,0 +1,15 @@
+type::{
+  annotations: closed::[],
+}
+valid::[
+  5,
+  "I love Ion Schema",
+  [ a::5, b::5 ],
+]
+invalid::[
+  a::5,
+  b::"I love Ion Schema",
+  c::[ a::5, b::5 ],
+  'null'::"Foo",
+]
+

--- a/constraints/annotations/closed_ordered_mixed.isl
+++ b/constraints/annotations/closed_ordered_mixed.isl
@@ -1,0 +1,19 @@
+type::{
+    annotations: closed::ordered::required::[a, b, optional::c],
+}
+valid::[
+    a::b::5,
+    a::b::c::5,
+]
+invalid::[
+    5,
+    a::5,
+    b::5,
+    b::a::5,
+    a::c::5,
+    b::c::5,
+    a::b::a::5,
+    a::b::c::a::5,
+    a::b::d::5,
+    a::b::c::d::5,
+]

--- a/constraints/annotations/closed_ordered_optional.isl
+++ b/constraints/annotations/closed_ordered_optional.isl
@@ -1,0 +1,22 @@
+type::{
+    annotations: closed::ordered::[a, b, c, d],
+}
+valid::[
+  5,
+  a::5,
+  b::5,
+  c::5,
+  a::b::5,
+  a::b::c::5,
+  a::d::5,
+  b::d::5,
+  b::c::d::5,
+  a::b::c::d::5,
+]
+invalid::[
+    a::a::b::5,
+    b::b::5,
+    d::b::a::5,
+    a::b::a::b::a::5,
+    a::b::c::d::d::5,
+]

--- a/constraints/annotations/closed_ordered_required.isl
+++ b/constraints/annotations/closed_ordered_required.isl
@@ -1,0 +1,17 @@
+type::{
+    annotations: closed::required::ordered::[a, b, c],
+}
+valid::[
+    a::b::c::5,
+]
+invalid::[
+    5,
+    a::5,
+    a::b::5,
+    a::b::c::d::5,
+    a::c::b::5,
+    b::c::a::5,
+    c::a::b::5,
+    a::a::b::c::5,
+    a::b::c::c::b::a::5,
+]

--- a/constraints/annotations/closed_ordered_required_2.isl
+++ b/constraints/annotations/closed_ordered_required_2.isl
@@ -1,0 +1,13 @@
+type::{
+    annotations: closed::required::ordered::[a, b, a, b],
+}
+valid::[
+    a::b::a::b::5,
+]
+invalid::[
+    5,
+    a::5,
+    a::b::5,
+    a::b::a::5,
+    a::b::a::b::a::5,
+]

--- a/constraints/annotations/closed_required.isl
+++ b/constraints/annotations/closed_required.isl
@@ -1,0 +1,17 @@
+type::{
+    annotations: closed::required::[a, b, c],
+}
+valid::[
+    a::b::c::5,
+    a::c::b::5,
+    b::c::a::5,
+    c::a::b::5,
+    a::a::b::c::5,
+    a::b::c::c::b::a::5,
+]
+invalid::[
+    5,
+    a::5,
+    a::b::5,
+    a::b::c::d::5,
+]

--- a/constraints/annotations/validation_closed.isl
+++ b/constraints/annotations/validation_closed.isl
@@ -1,0 +1,13 @@
+type::{
+  annotations: closed::[a, b, c],
+}
+test_validation::{
+  value: d::5,
+  violations: [
+    {
+      constraint: { annotations: closed::[a, b, c] },
+      code: unexpected_annotation,
+    },
+  ],
+}
+


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/amzn/ion-schema/pull/26

*Description of changes:*

These are test cases for https://github.com/amzn/ion-schema/pull/26 that did not get merged into `ion-schema-tests` when https://github.com/amzn/ion-schema-kotlin/pull/159 was merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
