### PR TITLE
Fix invalid ISL in a test case

### DIFF
--- a/constraints/annotations/ordered_mixed.isl
+++ b/constraints/annotations/ordered_mixed.isl
@@ -1,5 +1,5 @@
 type::{
-  annotations: ordered::optional::[a, required::b, c, required::d],
+  annotations: ordered::[a, required::b, c, required::d],
 }
 valid::[
      b::   d::5,


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

Removes the `optional::` annotation from the list of annotations. The `optional::` annotation is only allowed on list elements for the `annotations` constraint, not on the list itself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
