### PR TITLE
Adds additional test case for ordered_elements

### DIFF
--- a/constraints/ordered_elements/occurs_4.isl
+++ b/constraints/ordered_elements/occurs_4.isl
@@ -1,0 +1,22 @@
+type::{
+  ordered_elements:[
+    { type: int, occurs: optional },
+    { type: number, occurs: optional },
+    { type: any, occurs: required}
+  ]
+}
+
+valid::[
+  [1],
+  [1, 2],
+  [1, 2, 3],
+  [1, 2.0],
+  [1, foo],
+  [1.0, foo],
+  [1, 1.0, foo],
+]
+
+invalid::[
+  [1, 2, 3, 4],
+  [1, foo, foo],
+]


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/amzn/ion-schema/issues/62

**Description of changes:**

Adds test case for `ordered_elements` to cover the incorrect, unexpected behavior mentioned in https://github.com/amzn/ion-schema/issues/62.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
