### PR TITLE
Add test cases for timestamp precision ranges using 'min' and 'max'

### DIFF
--- a/constraints/timestamp_precision/min_and_max.isl
+++ b/constraints/timestamp_precision/min_and_max.isl
@@ -1,0 +1,25 @@
+type::{
+  timestamp_precision: range::[min, day],
+}
+valid::[
+  2000T,
+  2000-01T,
+  2000-01-01T,
+]
+invalid::[
+  2000-01-01T00:00Z,
+  2000-01-01T00:00:00Z,
+]
+
+type::{
+  timestamp_precision: range::[day, max],
+}
+valid::[
+  2000-01-01T,
+  2000-01-01T00:00Z,
+  2000-01-01T00:00:00Z,
+]
+invalid::[
+  2000T,
+  2000-01T,
+]


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/amzn/ion-schema-kotlin/issues/193

**Description of changes:**

Adds a test case to cover the cases in https://github.com/amzn/ion-schema-kotlin/issues/193.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
