### PR TITLE
Add test cases for codepoint_length that include codepoints made of multiple code units

### DIFF
--- a/constraints/codepoint_length/exact.isl
+++ b/constraints/codepoint_length/exact.isl
@@ -4,8 +4,10 @@ type::{
 valid::[
   '12345',
   "12345",
+  "1234\U00027546", // 5 codepoints; 6 code units
 ]
 invalid::[
   '1234',
   "123456",
+  "123\U00027546", // 4 codepoints; 5 code units
 ]


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/amzn/ion-schema-kotlin/issues/190

**Description of changes:**

Adds test cases to cover the bug mentioned in https://github.com/amzn/ion-schema-kotlin/issues/190.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
