### PR TITLE
Adds test for valid_values with unknown local offset mixed with other timestamp ranges

### DIFF
--- a/constraints/valid_values/timestamps_with_known_and_unknown_offsets.isl
+++ b/constraints/valid_values/timestamps_with_known_and_unknown_offsets.isl
@@ -1,0 +1,24 @@
+type::{
+  valid_values: [
+    // Ranges and single values are intentionally mixed to help prevent faulty
+    // logic that relies on ranges being before single values or vice versa.
+    2022T,
+    range::[2020-01-01T00:00Z, 2025-01-01T00:00Z],
+    2023T,
+    range::[2030-01-01T00:00Z, 2035-01-01T00:00Z],
+    2000T,
+  ],
+}
+valid::[
+  2022T,
+  2023T,
+  2000T,
+  2022-01-05T00:00:00Z
+]
+invalid::[
+  1995T,
+  2020T,
+  2021T,
+  2022-01T,
+  2022-01-05T00:00:00-00:00
+]


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

I've discovered a bug in `ion-schema-kotlin`, and this test case reproduces it. Essentially, there's an incorrect short-circuit evaluation of timestamps with unknown offsets in the `valid_values` constraint. If a timestamp with an unknown offset is compared to a range, `valid_values` will add an issue _even if there are other values that it could match_.

This test case should pass (according to the spec), but it is currently failing in `ion-schema-kotlin`.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
