### PR TITLE
Adds test cases for annotations constraint applied to documents

### DIFF
--- a/constraints/annotations/closed_no_annotations.isl
+++ b/constraints/annotations/closed_no_annotations.isl
@@ -11,5 +11,11 @@ invalid::[
   b::"I love Ion Schema",
   c::[ a::5, b::5 ],
   'null'::"Foo",
+  // Note that this is interpreted by the test runner as a document rather than a string that is annotated with document.
+  document::'''
+    foo
+    bar
+    baz
+  '''
 ]
 

--- a/constraints/annotations/unordered_optional.isl
+++ b/constraints/annotations/unordered_optional.isl
@@ -12,3 +12,12 @@ valid::[
   open_content::a::open_content::b::open_content::c::open_content::d::open_content::5,
 ]
 
+invalid::[
+  // Note that this is interpreted by the test runner as a document rather than a string that is annotated with document.
+  document::'''
+    foo
+    bar
+    baz
+  '''
+]
+


### PR DESCRIPTION
**Issue #, if available:**

Test cases for https://github.com/amzn/ion-schema/pull/73

**Description of changes:**

This change adds two test cases to make sure that a `document` does not match an `annotations` constraint that allows an empty list of annotations.

There are no new meaningful test cases we could for the `valid_values` constraint as applied to `document`s because there is no representation for a `document` literal in ISL. It is already impossible to construct a `valid_values` constraint that could match a `document`.



_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
