### PR TITLE
Adds test cases for Ion Schema 2.0 `*_length` and logic constraints

### DIFF
--- a/ion_schema_2_0/constraints/all_of.isl
+++ b/ion_schema_2_0/constraints/all_of.isl
@@ -1,0 +1,153 @@
+$ion_schema_2_0
+
+type::{
+  name: all_of_two_types,
+  all_of: [
+    number,
+    $int,
+  ]
+}
+
+$test::{
+  type: all_of_two_types,
+  should_accept_as_valid: [
+    1,
+    2,
+    3,
+  ],
+  should_reject_as_invalid: [
+    null.int,
+    1e0,
+    1d0,
+  ],
+}
+
+type::{
+  name: all_of_one_type,
+  all_of: [
+    int,
+  ]
+}
+
+$test::{
+  type: all_of_one_type,
+  should_accept_as_valid: [
+    1,
+    2,
+    3,
+  ],
+  should_reject_as_invalid: [
+    null.int,
+    1e0,
+    1d0,
+  ],
+}
+
+type::{
+  // all_of is a conjunction. An empty conjunction is always true.
+  name: all_of_zero_types,
+  all_of: []
+}
+
+$test::{
+  type: all_of_zero_types,
+  should_accept_as_valid: [
+    true,
+    1,
+    2d0,
+    3e0,
+    "Hello World!",
+    foo,
+    {{ "abc" }},
+    {{ aGVsbG8= }},
+    2022T,
+    [1, 2, 3],
+    (x + y),
+    {},
+    foo::bar::baz,
+    null,
+    null.bool,
+    null.int,
+    null.float,
+    null.decimal,
+    null.string,
+    null.symbol,
+    null.blob,
+    null.clob,
+    null.timestamp,
+    null.list,
+    null.sexp,
+    null.struct,
+  ],
+  should_reject_as_invalid: [
+    // Nothing
+  ],
+}
+
+type::{
+  name: all_of_with_inline_import,
+  all_of: [ { id: 'util.isl', type: positive_int } ],
+}
+
+$test::{
+  type: all_of_with_inline_import,
+  should_accept_as_valid: [
+    1,
+    2,
+    3,
+  ],
+  should_reject_as_invalid: [
+    null.int,
+    -1,
+    0,
+    1.0,
+  ],
+}
+
+type::{
+  name: all_of_with_inline_type,
+  all_of: [ { codepoint_length: 5 } ],
+}
+
+$test::{
+  type: all_of_with_inline_type,
+  should_accept_as_valid: [
+    "Hello", World
+  ],
+  should_reject_as_invalid: [
+    null.string,
+    null.symbol,
+    "Greetings", Earthling,
+    "Hi", Dude,
+  ],
+}
+
+$test::{
+  description: "all_of must be a list of type references",
+  invalid_types: [
+    { all_of: null },
+    { all_of: null.int },
+    { all_of: 5 },
+    { all_of: int },
+    { all_of: "$int" },
+    { all_of: { container_length: 5 } },
+    { all_of: (int float) },
+    { all_of: [int, float, not_a_real_type] },
+    { all_of: [int, float, ()] },
+    { all_of: range::[1, 5] },
+  ]
+}
+
+$test::{
+  description: "all_of must not have a variably occurring type reference",
+  invalid_types: [
+    { all_of: [{ occurs: 2, type: int }] },
+  ],
+}
+
+$test::{
+  description: "all_of must not have a named type definition",
+  invalid_types: [
+    { all_of: [{ name: foo, type: int }] },
+  ],
+}

--- a/ion_schema_2_0/constraints/any_of.isl
+++ b/ion_schema_2_0/constraints/any_of.isl
@@ -1,0 +1,165 @@
+$ion_schema_2_0
+
+type::{
+  name: any_of_three_types,
+  any_of: [
+    decimal,
+    float,
+    $int,
+  ]
+}
+
+$test::{
+  type: any_of_three_types,
+  should_accept_as_valid: [
+    1,
+    2,
+    3,
+    null.int,
+    1e0,
+    2e0,
+    1d0,
+    2e0,
+  ],
+  should_reject_as_invalid: [
+    null.float,
+    null.decimal,
+    {},
+    null,
+    "Hello",
+    foo,
+    [1, 2, 3],
+    (x + y),
+    2022T,
+  ],
+}
+
+type::{
+  name: any_of_one_type,
+  any_of: [
+    int,
+  ]
+}
+
+$test::{
+  type: any_of_one_type,
+  should_accept_as_valid: [
+    1,
+    2,
+    3,
+  ],
+  should_reject_as_invalid: [
+    null.int,
+    1e0,
+    1d0,
+  ],
+}
+
+type::{
+  // any_of is a disjunction. An empty disjunction is always false.
+  name: any_of_zero_types,
+  any_of: []
+}
+
+$test::{
+  type: any_of_zero_types,
+  should_accept_as_valid: [
+    // Nothing
+  ],
+  should_reject_as_invalid: [
+    true,
+    1,
+    2d0,
+    3e0,
+    "Hello World!",
+    foo,
+    {{ "abc" }},
+    {{ aGVsbG8= }},
+    2022T,
+    [1, 2, 3],
+    (x + y),
+    {},
+    foo::bar::baz,
+    null,
+    null.bool,
+    null.int,
+    null.float,
+    null.decimal,
+    null.string,
+    null.symbol,
+    null.blob,
+    null.clob,
+    null.timestamp,
+    null.list,
+    null.sexp,
+    null.struct,
+  ]
+}
+
+type::{
+  name: any_of_with_inline_import,
+  any_of: [ { id: 'util.isl', type: positive_int } ],
+}
+
+$test::{
+  type: any_of_with_inline_import,
+  should_accept_as_valid: [
+    1,
+    2,
+    3,
+  ],
+  should_reject_as_invalid: [
+    null.int,
+    -1,
+    0,
+    1.0,
+  ],
+}
+
+type::{
+  name: any_of_with_inline_type,
+  any_of: [ { codepoint_length: 5 } ],
+}
+
+$test::{
+  type: any_of_with_inline_type,
+  should_accept_as_valid: [
+    "Hello", World
+  ],
+  should_reject_as_invalid: [
+    null.string,
+    null.symbol,
+    "Greetings", Earthling,
+    "Hi", Dude,
+  ],
+}
+
+$test::{
+  description: "any_of must be a list of type references",
+  invalid_types: [
+    { any_of: null },
+    { any_of: null.int },
+    { any_of: 5 },
+    { any_of: int },
+    { any_of: "$int" },
+    { any_of: { container_length: 5 } },
+    { any_of: (int float) },
+    { any_of: [int, float, not_a_real_type] },
+    { any_of: [int, float, ()] },
+    { any_of: range::[1, 5] },
+  ]
+}
+
+$test::{
+  description: "any_of must not have a variably occurring type reference",
+  invalid_types: [
+    { any_of: [{ occurs: 2, type: int }] },
+  ],
+}
+
+$test::{
+  description: "any_of must not have a named type definition",
+  invalid_types: [
+    { any_of: [{ name: foo, type: int }] },
+  ],
+}

--- a/ion_schema_2_0/constraints/byte_length.isl
+++ b/ion_schema_2_0/constraints/byte_length.isl
@@ -1,0 +1,103 @@
+$ion_schema_2_0
+
+type::{
+  name: 'byte_length: 5',
+  byte_length: 5,
+}
+
+$test::{
+  type: 'byte_length: 5',
+  should_accept_as_valid: [
+    {{"12345"}},
+    {{ aGVsbG8= }},
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.blob,
+    null.clob,
+    {{ aGVs }},
+    {{ aGVsbG89dy4= }},
+    {{ "" }},
+    {{"1234"}},
+    {{"123456"}},
+    "abcde",
+  ]
+}
+
+type::{
+  name: 'byte_length: range::[5, 10]',
+  byte_length: range::[5, 10],
+}
+
+$test::{
+  type: 'byte_length: range::[5, 10]',
+  should_accept_as_valid:[
+    {{"12345"}},
+    {{"1234567890"}},
+    {{ aGVsbG8= }},
+    {{ aGVsbG89dy4VGg== }},
+  ],
+  should_reject_as_invalid:[
+    null,
+    null.blob,
+    null.clob,
+    {{ aGVsbg== }},
+    {{ aGVsbG89dydhfV4= }},
+    {{ "" }},
+    {{"1234"}},
+    {{"1234567890a"}},
+    "abcdef",
+  ],
+}
+
+$test::{
+  description: "byte_length may not be null.int",
+  invalid_types: [
+    { byte_length: null.int },
+  ]
+}
+$test::{
+  description: "byte_length must be greater than or equal to zero",
+  invalid_types: [
+    { byte_length: -1 },
+  ]
+}
+$test::{
+  description: "byte_length range lower bound must be greater than or equal to zero",
+  invalid_types: [
+    { byte_length: range::[-1, 1] },
+  ]
+}
+$test::{
+  description: "byte_length range must be a valid integer range",
+  invalid_types:[
+    { byte_length: range::(1 2) },
+    { byte_length: range::[min, max] },
+    { byte_length: range::null.list },
+    { byte_length: range::[2, 1] },
+    { byte_length: range::[1] },
+    { byte_length: range::[1, 2, 3] },
+    { byte_length: range::[1d0, 2] },
+    { byte_length: range::[1, 2d0] },
+    { byte_length: range::[1e0, 2] },
+    { byte_length: range::[1, 2e0] },
+    { byte_length: range::[exclusive::1, exclusive::2] },
+  ]
+}
+$test::{
+  description: "byte_length must be an integer or a range",
+  invalid_types:[
+    { byte_length: [1, 2] },
+    { byte_length: (1 2) },
+    { byte_length: { min: 1, max: 2} },
+    { byte_length: null },
+    { byte_length: min },
+    { byte_length: max },
+    { byte_length: "foo" },
+    { byte_length: false },
+    { byte_length: 2d0 },
+    { byte_length: 3e0 },
+    { byte_length: {{ "1" }} },
+    { byte_length: {{ aGVsbG8= }} },
+  ]
+}

--- a/ion_schema_2_0/constraints/codepoint_length.isl
+++ b/ion_schema_2_0/constraints/codepoint_length.isl
@@ -1,0 +1,91 @@
+$ion_schema_2_0
+
+type::{
+  name: 'codepoint_length: 5',
+  codepoint_length: 5,
+}
+
+$test::{
+  type: 'codepoint_length: 5',
+  should_accept_as_valid: [
+    '12345',
+    "12345",
+    "1234\U00027546", // 5 codepoints; 6 code units
+  ],
+  should_reject_as_invalid: [
+    '1234',
+    "123456",
+    "123\U00027546", // 4 codepoints; 5 code units
+  ]
+}
+
+type::{
+  name: 'codepoint_length: range::[5, 10]',
+  codepoint_length: range::[5, 10],
+}
+
+$test::{
+  type: 'codepoint_length: range::[5, 10]',
+  should_accept_as_valid:[
+    '12345',
+    "1234567890",
+    "123456789\U00027546", // 10 codepoints; 11 code units
+  ],
+  should_reject_as_invalid:[
+    '1234',
+    "12345678901",
+    "123\U00027546", // 4 codepoints; 5 code units
+  ],
+}
+
+$test::{
+  description: "codepoint_length may not be null.int",
+  invalid_types: [
+    { codepoint_length: null.int },
+  ]
+}
+$test::{
+  description: "codepoint_length must be greater than or equal to zero",
+  invalid_types: [
+    { codepoint_length: -1 },
+  ]
+}
+$test::{
+  description: "codepoint_length range lower bound must be greater than or equal to zero",
+  invalid_types: [
+    { codepoint_length: range::[-1, 1] },
+  ]
+}
+$test::{
+  description: "codepoint_length range must be a valid integer range",
+  invalid_types:[
+    { codepoint_length: range::(1 2) },
+    { codepoint_length: range::[min, max] },
+    { codepoint_length: range::null.list },
+    { codepoint_length: range::[2, 1] },
+    { codepoint_length: range::[1] },
+    { codepoint_length: range::[1, 2, 3] },
+    { codepoint_length: range::[1d0, 2] },
+    { codepoint_length: range::[1, 2d0] },
+    { codepoint_length: range::[1e0, 2] },
+    { codepoint_length: range::[1, 2e0] },
+    { codepoint_length: range::[exclusive::1, exclusive::2] },
+  ]
+}
+$test::{
+  description: "codepoint_length must be an integer or a range",
+  invalid_types:[
+    { codepoint_length: [1, 2] },
+    { codepoint_length: (1 2) },
+    { codepoint_length: { min: 1, max: 2} },
+    { codepoint_length: null },
+    { codepoint_length: min },
+    { codepoint_length: max },
+    { codepoint_length: "foo" },
+    { codepoint_length: false },
+    { codepoint_length: 2d0 },
+    { codepoint_length: 3e0 },
+    { codepoint_length: {{ "1" }} },
+    { codepoint_length: {{ aGVsbG8= }} },
+  ]
+}

--- a/ion_schema_2_0/constraints/container_length.isl
+++ b/ion_schema_2_0/constraints/container_length.isl
@@ -1,0 +1,114 @@
+$ion_schema_2_0
+
+type::{
+  name: 'container_length: 5',
+  container_length: 5,
+}
+
+$test::{
+  type: 'container_length: 5',
+  should_accept_as_valid: [
+    [1, 2, 3, 4, 5],
+    (a b c d e),
+    { a: 1, b: 2, c: 3, d: 4, e: 5 },
+    { a: 1, a: 1, a: 1, b: 2, b: 2 },
+    document::(a b c d e)
+  ],
+  should_reject_as_invalid: [
+    null.list,
+    null.sexp,
+    null.struct,
+    [1, 2, 3, 4],
+    [1, 2, 3, 4, 5, 6],
+    (a b c d),
+    (a b c d e f),
+    { a: 1, b: 2, c: 3, d: 4 },
+    { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 },
+    document::(a b c d),
+    document::(a b c d e f),
+  ]
+}
+
+type::{
+  name: 'container_length: range::[5, 10]',
+  container_length: range::[5, 10],
+}
+
+$test::{
+  type: 'container_length: range::[5, 10]',
+  should_accept_as_valid:[
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+    (a b c d e),
+    (a b c d e f g h i j),
+    document::(a b c d e),
+    document::(a b c d e f g h i j),
+    { a: 1, b: 2, c: 3, d: 4, e: 5 },
+    { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10 },
+  ],
+  should_reject_as_invalid:[
+    null.list,
+    null.sexp,
+    null.struct,
+    [1, 2, 3, 4],
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    (a b c d),
+    (a b c d e f g h i j k),
+    { a: 1, b: 2, c: 3, d: 4 },
+    { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10, k: 11 },
+    document::(a b c d),
+    document::(a b c d e f g h i j k),
+  ],
+}
+
+$test::{
+  description: "container_length may not be null.int",
+  invalid_types: [
+    { container_length: null.int },
+  ]
+}
+$test::{
+  description: "container_length must be greater than or equal to zero",
+  invalid_types: [
+    { container_length: -1 },
+  ]
+}
+$test::{
+  description: "container_length range lower bound must be greater than or equal to zero",
+  invalid_types: [
+    { container_length: range::[-1, 1] },
+  ]
+}
+$test::{
+  description: "container_length range must be a valid integer range",
+  invalid_types:[
+    { container_length: range::(1 2) },
+    { container_length: range::[min, max] },
+    { container_length: range::null.list },
+    { container_length: range::[2, 1] },
+    { container_length: range::[1] },
+    { container_length: range::[1, 2, 3] },
+    { container_length: range::[1d0, 2] },
+    { container_length: range::[1, 2d0] },
+    { container_length: range::[1e0, 2] },
+    { container_length: range::[1, 2e0] },
+    { container_length: range::[exclusive::1, exclusive::2] },
+  ]
+}
+$test::{
+  description: "container_length must be an integer or a range",
+  invalid_types:[
+    { container_length: [1, 2] },
+    { container_length: (1 2) },
+    { container_length: { min: 1, max: 2} },
+    { container_length: null },
+    { container_length: min },
+    { container_length: max },
+    { container_length: "foo" },
+    { container_length: false },
+    { container_length: 2d0 },
+    { container_length: 3e0 },
+    { container_length: {{ "1" }} },
+    { container_length: {{ aGVsbG8= }} },
+    ]
+}

--- a/ion_schema_2_0/constraints/not.isl
+++ b/ion_schema_2_0/constraints/not.isl
@@ -1,0 +1,148 @@
+$ion_schema_2_0
+
+type::{
+  name: 'not: any',
+  not: any,
+}
+
+$test::{
+  type: 'not: any',
+  should_accept_as_valid: [
+    null,
+    null.bool,
+    null.int,
+    null.float,
+    null.decimal,
+    null.string,
+    null.symbol,
+    null.blob,
+    null.clob,
+    null.timestamp,
+    null.list,
+    null.sexp,
+    null.struct,
+  ],
+  should_reject_as_invalid: [
+    true,
+    1,
+    2d0,
+    3e0,
+    "Hello",
+    foo,
+    {{ "abc" }},
+    {{ aGVsbG8= }},
+    2022T,
+    [1, 2, 3],
+    (x + y),
+    {},
+  ],
+}
+
+type::{
+  name: not_inline_type,
+  not: { codepoint_length: 5 }
+}
+
+$test::{
+  type: not_inline_type,
+  should_accept_as_valid: [
+    true,
+    1,
+    2d0,
+    3e0,
+    "Hello World!",
+    foo,
+    {{ "abc" }},
+    {{ aGVsbG8= }},
+    2022T,
+    [1, 2, 3],
+    (x + y),
+    {},
+    null,
+    null.bool,
+    null.int,
+    null.float,
+    null.decimal,
+    null.string,
+    null.symbol,
+    null.blob,
+    null.clob,
+    null.timestamp,
+    null.list,
+    null.sexp,
+    null.struct,
+  ],
+  should_reject_as_invalid: [
+    abcde,
+    "fghij",
+  ],
+}
+
+type::{
+  name: not_inline_import,
+  not: { id: 'util.isl', type: positive_int }
+}
+
+$test::{
+  type: not_inline_import,
+  should_accept_as_valid: [
+    true,
+    0,
+    1d0,
+    2e0,
+    "Hello",
+    foo,
+    {{ "abc" }},
+    {{ aGVsbG8= }},
+    2022T,
+    [1, 2, 3],
+    (x + y),
+    {},
+    null,
+    null.bool,
+    null.int,
+    null.float,
+    null.decimal,
+    null.string,
+    null.symbol,
+    null.blob,
+    null.clob,
+    null.timestamp,
+    null.list,
+    null.sexp,
+    null.struct,
+  ],
+  should_reject_as_invalid: [
+    1,
+    10,
+    100,
+    1000,
+  ],
+}
+
+$test::{
+  description: "not must be a type reference",
+  invalid_types: [
+    { not: null },
+    { not: null.int },
+    { not: 5 },
+    { not: "$int" },
+    { not: (int float) },
+    { not: [int, float] },
+    { not: range::[1, 5] },
+  ]
+}
+
+$test::{
+  description: "not must not be a variably occurring type reference",
+  invalid_types: [
+    { not: { occurs: 2, type: int } },
+  ],
+}
+
+$test::{
+  description: "not must not be a named type definition",
+  invalid_types: [
+    { not: { name: foo, type: int } },
+  ],
+}

--- a/ion_schema_2_0/constraints/one_of.isl
+++ b/ion_schema_2_0/constraints/one_of.isl
@@ -1,0 +1,173 @@
+$ion_schema_2_0
+
+type::{
+  name: one_of_three_types,
+  one_of: [
+    { annotations: required::[foo] },
+    { valid_values: range::[0, 10] },
+    $int,
+  ]
+}
+
+$test::{
+  type: one_of_three_types,
+  should_accept_as_valid: [
+    -1,
+    2e0,
+    3d0,
+    null.int,
+    foo::{ a: 1, b: 2 }
+  ],
+  should_reject_as_invalid: [
+    // Doesn't match any types
+    null.float,
+    null.decimal,
+    {},
+    null,
+    "Hello",
+    foo,
+    [1, 2, 3],
+    (x + y),
+    2022T,
+    // Matches 2 types
+    foo::null.int,
+    foo::1d0,
+    foo::2e0,
+    0,
+    10,
+    // Matches 3 types
+    foo::0,
+    foo::10
+  ],
+}
+
+type::{
+  name: one_of_one_type,
+  one_of: [
+    int,
+  ]
+}
+
+$test::{
+  type: one_of_one_type,
+  should_accept_as_valid: [
+    1,
+    2,
+    3,
+  ],
+  should_reject_as_invalid: [
+    null.int,
+    1e0,
+    1d0,
+  ],
+}
+
+type::{
+  // one_of is a disjunction. An empty disjunction is always false.
+  name: one_of_zero_types,
+  one_of: []
+}
+
+$test::{
+  type: one_of_zero_types,
+  should_accept_as_valid: [
+    // Nothing
+  ],
+  should_reject_as_invalid: [
+    true,
+    1,
+    2d0,
+    3e0,
+    "Hello World!",
+    foo,
+    {{ "abc" }},
+    {{ aGVsbG8= }},
+    2022T,
+    [1, 2, 3],
+    (x + y),
+    {},
+    foo::bar::baz,
+    null,
+    null.bool,
+    null.int,
+    null.float,
+    null.decimal,
+    null.string,
+    null.symbol,
+    null.blob,
+    null.clob,
+    null.timestamp,
+    null.list,
+    null.sexp,
+    null.struct,
+  ]
+}
+
+type::{
+  name: one_of_with_inline_import,
+  one_of: [ { id: 'util.isl', type: positive_int } ],
+}
+
+$test::{
+  type: one_of_with_inline_import,
+  should_accept_as_valid: [
+    1,
+    2,
+    3,
+  ],
+  should_reject_as_invalid: [
+    null.int,
+    -1,
+    0,
+    1.0,
+  ],
+}
+
+
+type::{
+  name: one_of_with_inline_type,
+  one_of: [ { codepoint_length: 5 } ],
+}
+
+$test::{
+  type: one_of_with_inline_type,
+  should_accept_as_valid: [
+    "Hello", World
+  ],
+  should_reject_as_invalid: [
+    null.string,
+    null.symbol,
+    "Greetings", Earthling,
+    "Hi", Dude,
+  ],
+}
+
+$test::{
+  description: "one_of must be a list of type references",
+  invalid_types: [
+    { one_of: null },
+    { one_of: null.int },
+    { one_of: 5 },
+    { one_of: int },
+    { one_of: "$int" },
+    { one_of: { container_length: 5 } },
+    { one_of: (int float) },
+    { one_of: [int, float, not_a_real_type] },
+    { one_of: [int, float, ()] },
+    { one_of: range::[1, 5] },
+  ]
+}
+
+$test::{
+  description: "one_of must not have a variably occurring type reference",
+  invalid_types: [
+    { one_of: [{ occurs: 2, type: int }] },
+  ],
+}
+
+$test::{
+  description: "one_of must not have a named type definition",
+  invalid_types: [
+    { one_of: [{ name: foo, type: int }] },
+  ],
+}

--- a/ion_schema_2_0/constraints/type.isl
+++ b/ion_schema_2_0/constraints/type.isl
@@ -1,0 +1,148 @@
+$ion_schema_2_0
+
+type::{
+  name: 'type: any',
+  type: any,
+}
+
+$test::{
+  type: 'type: any',
+  should_accept_as_valid: [
+    true,
+    1,
+    2d0,
+    3e0,
+    "Hello",
+    foo,
+    {{ "abc" }},
+    {{ aGVsbG8= }},
+    2022T,
+    [1, 2, 3],
+    (x + y),
+    {},
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.bool,
+    null.int,
+    null.float,
+    null.decimal,
+    null.string,
+    null.symbol,
+    null.blob,
+    null.clob,
+    null.timestamp,
+    null.list,
+    null.sexp,
+    null.struct,
+  ],
+}
+
+type::{
+  name: type_inline_type,
+  type: { codepoint_length: 5 }
+}
+
+$test::{
+  type: type_inline_type,
+  should_accept_as_valid: [
+    abcde,
+    "fghij",
+  ],
+  should_reject_as_invalid: [
+    true,
+    1,
+    2d0,
+    3e0,
+    "Hello World!",
+    foo,
+    {{ "abc" }},
+    {{ aGVsbG8= }},
+    2022T,
+    [1, 2, 3],
+    (x + y),
+    {},
+    null,
+    null.bool,
+    null.int,
+    null.float,
+    null.decimal,
+    null.string,
+    null.symbol,
+    null.blob,
+    null.clob,
+    null.timestamp,
+    null.list,
+    null.sexp,
+    null.struct,
+  ],
+}
+
+type::{
+  name: type_inline_import,
+  type: { id: 'util.isl', type: positive_int }
+}
+
+$test::{
+  type: type_inline_import,
+  should_accept_as_valid: [
+    1,
+    10,
+    100,
+    1000,
+  ],
+  should_reject_as_invalid: [
+    true,
+    0,
+    1d0,
+    2e0,
+    "Hello",
+    foo,
+    {{ "abc" }},
+    {{ aGVsbG8= }},
+    2022T,
+    [1, 2, 3],
+    (x + y),
+    {},
+    null,
+    null.bool,
+    null.int,
+    null.float,
+    null.decimal,
+    null.string,
+    null.symbol,
+    null.blob,
+    null.clob,
+    null.timestamp,
+    null.list,
+    null.sexp,
+    null.struct,
+  ],
+}
+
+$test::{
+  description: "type must be a type reference",
+  invalid_types: [
+    { type: null },
+    { type: null.int },
+    { type: 5 },
+    { type: "$int" },
+    { type: (int float) },
+    { type: [int, float] },
+    { type: range::[1, 5] },
+  ]
+}
+
+$test::{
+  description: "type must not be a variably occurring type reference",
+  invalid_types: [
+    { type: { occurs: 2, type: int } },
+  ],
+}
+
+$test::{
+  description: "type must not be a named type definition",
+  invalid_types: [
+    { type: { name: foo, type: int } },
+  ],
+}

--- a/ion_schema_2_0/constraints/utf8_byte_length.isl
+++ b/ion_schema_2_0/constraints/utf8_byte_length.isl
@@ -1,0 +1,93 @@
+$ion_schema_2_0
+
+type::{
+  name: 'utf8_byte_length: 5',
+  utf8_byte_length: 5,
+}
+
+$test::{
+  type: 'utf8_byte_length: 5',
+  should_accept_as_valid: [
+    '12345',
+    "12345",
+    '\u00A2\u20AC'
+  ],
+  should_reject_as_invalid: [
+    '1234',
+    '123456',
+    '\u00A2\u00A2',
+    '\u20AC\u20AC'
+  ]
+}
+
+type::{
+  name: 'utf8_byte_length: range::[5, 10]',
+  utf8_byte_length: range::[5, 10],
+}
+
+$test::{
+  type: 'utf8_byte_length: range::[5, 10]',
+  should_accept_as_valid:[
+    '12345',
+    "1234567890",
+    "\u00A2\u20AC",
+    '\u20AC\u20AC'
+  ],
+  should_reject_as_invalid:[
+    '1234',
+    "12345678901",
+    '\u00A2\u00A2'
+  ],
+}
+
+$test::{
+  description: "utf8_byte_length may not be null.int",
+  invalid_types: [
+    { utf8_byte_length: null.int },
+  ]
+}
+$test::{
+  description: "utf8_byte_length must be greater than or equal to zero",
+  invalid_types: [
+    { utf8_byte_length: -1 },
+  ]
+}
+$test::{
+  description: "utf8_byte_length range lower bound must be greater than or equal to zero",
+  invalid_types: [
+    { utf8_byte_length: range::[-1, 1] },
+  ]
+}
+$test::{
+  description: "utf8_byte_length range must be a valid integer range",
+  invalid_types:[
+    { utf8_byte_length: range::(1 2) },
+    { utf8_byte_length: range::[min, max] },
+    { utf8_byte_length: range::null.list },
+    { utf8_byte_length: range::[2, 1] },
+    { utf8_byte_length: range::[1] },
+    { utf8_byte_length: range::[1, 2, 3] },
+    { utf8_byte_length: range::[1d0, 2] },
+    { utf8_byte_length: range::[1, 2d0] },
+    { utf8_byte_length: range::[1e0, 2] },
+    { utf8_byte_length: range::[1, 2e0] },
+    { utf8_byte_length: range::[exclusive::1, exclusive::2] },
+  ]
+}
+$test::{
+  description: "utf8_byte_length must be an integer or a range",
+  invalid_types:[
+    { utf8_byte_length: [1, 2] },
+    { utf8_byte_length: (1 2) },
+    { utf8_byte_length: { min: 1, max: 2} },
+    { utf8_byte_length: null },
+    { utf8_byte_length: min },
+    { utf8_byte_length: max },
+    { utf8_byte_length: "foo" },
+    { utf8_byte_length: false },
+    { utf8_byte_length: 2d0 },
+    { utf8_byte_length: 3e0 },
+    { utf8_byte_length: {{ "1" }} },
+    { utf8_byte_length: {{ aGVsbG8= }} },
+  ]
+}

--- a/ion_schema_2_0/util.isl
+++ b/ion_schema_2_0/util.isl
@@ -1,0 +1,8 @@
+$ion_schema_2_0
+
+// A type that can be used for importing into other test case ISL files
+type::{
+  name: positive_int,
+  type: int,
+  valid_values: range::[1, max],
+}


### PR DESCRIPTION
**Issue #, if available:**

#32 

**Description of changes:**

Adds test cases for the `*_length`, `any_of`, `all_of`, `one_of`, `type`, and `not` constraints.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
