### PR TITLE
Adds a GHA workflow to validate test case files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: "Validate Test Case Syntax"
+
+on:
+  push:
+  pull_request:
+    branches:
+      # Branches from forks have the form 'user:branch-name' so we only run this job on pull_request events for
+      # branches that look like fork branches. Without this we would end up running this job twice for non-forked
+      # PRs, once for the push and then once for opening the PR.
+      # Taken from https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/10
+      - '**:**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Ion CLI
+        run: cargo install ion-cli@0.4.1
+      - name: Run validation script
+        run: ./validate-test-cases
+

--- a/ion_schema_1_0/constraints/occurs/ordered_elements.isl
+++ b/ion_schema_1_0/constraints/occurs/ordered_elements.isl
@@ -1,7 +1,7 @@
 $ion_schema_1_0
 // default 'occurs' behavior for each ordered_elements type is:
 //   occurs: 1
-//
+
 type::{
   name: occurs_ordered_elements,
   ordered_elements: [

--- a/ion_schema_1_0/schema/deferred_type_resolution.isl
+++ b/ion_schema_1_0/schema/deferred_type_resolution.isl
@@ -3,7 +3,7 @@ $ion_schema_1_0
 // asserts that all constraints that have a type reference work when
 // the referenced type is defined later in the ISL.  in such cases,
 // resolution of the type reference is deferred until it is found.
-//
+
 schema_header::{
 }
 type::{

--- a/ion_schema_tests.isl
+++ b/ion_schema_tests.isl
@@ -1,0 +1,50 @@
+$ion_schema_1_0
+
+type::{
+  name: ion_schema_test_case,
+  annotations: closed::required::[$test],
+  one_of: [
+    {
+      container_length: range::[2, 3],
+      fields: {
+        type: { type: symbol, occurs: required },
+        should_accept_as_valid: list,
+        should_reject_as_invalid: list,
+      },
+      content: closed,
+    },
+    {
+      fields: {
+        description: { type: string, occurs: required },
+        invalid_schema: { type: sexp, occurs: required }
+      },
+      content: closed,
+    },
+    {
+      fields: {
+        description: { type: string, occurs: required },
+        invalid_types: { type: list, occurs: required }
+      },
+      content: closed,
+    },
+  ]
+}
+
+type::{
+  // Valid test case or not a test at all
+  name: maybe_test_case,
+  type: $any,
+  one_of: [
+    // All elements must be a valid test case
+    ion_schema_test_case,
+    // Or they must not have the `$test` annotation
+    { type: $any, not: { annotations: required::[$test] } },
+  ]
+}
+
+type::{
+  name: ion_schema_test_file,
+  // Following line is commented out because ion-schema-rust doesn't recognized document, as of ion-cli@v0.4.1
+  // type: document,
+  element: maybe_test_case,
+}

--- a/validate-test-cases
+++ b/validate-test-cases
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This is a MVP validation tool for ion-schema-tests
+# It is limited because:
+#   - ion-cli support for validation is incomplete
+#   - there is no convenient way to manipulate the Ion-encoded validation output (i.e. something like `iq`)
+#
+# This script uses ion-cli@0.4.1.
+# It may not work with other versions, but there it no known reason it can't be modified to use a newer version
+# of ion-cli if a new version is released with breaking changes.
+#
+# TODO: In future, we may want to consider replacing this script with e.g. a python script so that we can take
+# advantage of an Ion library that exposes more functionality than the ion-cli does.
+
+invalid_files=0
+for file in $(find . -name '*.isl' -print); do
+  # Need to add " | tail -n +2" to get rid of the "Validation result" line
+  result=$(ion beta schema validate -i "$file" -t "maybe_test_case" -d . -s ion_schema_tests.isl | tail -n +2)
+  # No CLI tool for querying Ion data, so we use grep... :/
+  if echo "$result" | grep -q 'result: "Invalid"'; then
+    echo "$file"
+    echo "$result" | ion dump # pretty-prints the Ion
+    invalid_files=$((invalid_files+1))
+  fi
+done
+
+if [[ $invalid_files -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**

Adds a GHA workflow to validate test case files. This includes:
* A schema that defines a valid test case file
* A script that runs `ion beta schema validate` on all test files
* A workflow that installs `ion-cli` and runs the validation script
* Removes empty line comments from two ISL files because `ion-rust` cannot parse them

The output is a little rough to use, but this is at least a start.

Examples of this workflow running:
* Fail: https://github.com/popematt/ion-schema-tests/actions/runs/3103001669/jobs/5025854836
* Pass: https://github.com/popematt/ion-schema-tests/actions/runs/3103003819/jobs/5025859515


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
