### PR TITLE
Adds test cases for annotations, field_names, fields, ordered_elements for Ion Schema 2.0

### DIFF
--- a/ion_schema_2_0/constraints/annotations-simplified.isl
+++ b/ion_schema_2_0/constraints/annotations-simplified.isl
@@ -1,0 +1,132 @@
+$ion_schema_2_0
+
+type::{
+  name: 'annotations: closed::[foo, bar]',
+  annotations: closed::[foo, bar],
+}
+
+$test::{
+  type: 'annotations: closed::[foo, bar]',
+  should_accept_as_valid: [
+    0,
+    foo::1,
+    bar::2.0,
+    foo::bar::3e0,
+    foo::foo::'4',
+    bar::foo::bar::foo::"5",
+    foo::null,
+  ],
+  should_reject_as_invalid: [
+    baz::1,
+    foo::baz::2,
+    bar::baz::3,
+    foo::bar::baz::4,
+    document::(),
+  ],
+}
+
+type::{
+  // Important use case—no annotations allowed
+  name: 'annotations: closed::[]',
+  annotations: closed::[],
+}
+
+$test::{
+  type: 'annotations: closed::[]',
+  should_accept_as_valid: [
+    0,
+    true,
+    null,
+    [],
+    (foo::bar),
+    "Hello world!",
+  ],
+  should_reject_as_invalid: [
+    foo::1,
+    ''::2,
+    document::(),
+  ],
+}
+
+type::{
+  name: 'annotations: required::[foo, bar]',
+  annotations: required::[foo, bar],
+}
+
+$test::{
+  type: 'annotations: required::[foo, bar]',
+  should_accept_as_valid: [
+    foo::bar::1,
+    bar::foo::2,
+    foo::bar::baz::3,
+    foo::bar::baz::bar::foo::4,
+    lorem::ipsum::quando::omni::flunkus::moritae::foo::bar::baz::5,
+    foo::bar::null,
+  ],
+  should_reject_as_invalid: [
+    1,
+    foo::2,
+    bar::3,
+    bar::baz::4,
+    bar::bar::bar::5,
+    foo::bar,
+    foo::[bar::baz],
+  ],
+}
+
+type::{
+  name: 'annotations: closed::required::[foo, bar]',
+  annotations: closed::required::[foo, bar],
+}
+
+$test::{
+  type: 'annotations: closed::required::[foo, bar]',
+  should_accept_as_valid: [
+    foo::bar::1,
+    bar::foo::2,
+    foo::bar::bar::3,
+    foo::bar::foo::4,
+    foo::bar::null
+  ],
+  should_reject_as_invalid: [
+    1,
+    foo::2,
+    bar::3,
+    foo::bar::baz::4,
+    bar::bar::bar::5,
+    quando::omni::flunkus::moritae::6,
+    foo::bar,
+    foo::[bar::baz],
+  ],
+}
+
+$test::{
+  description: "annotations (simplified) list must be annotated with required or closed",
+  invalid_types: [
+    { annotations: [foo, bar] },
+  ]
+}
+$test::{
+  description: "annotations (simplified) list must not be annotated with anything other that required or closed",
+  invalid_types: [
+    { annotations: closed::ordered::[foo, bar] },
+  ]
+}
+$test::{
+  description: "annotations (simplified) list must not have any annotations on elements of list",
+  invalid_types: [
+    { annotations: required::[optional::foo, bar] },
+  ]
+}
+$test::{
+  description: "annotations (simplified) list must only contain symbols",
+  invalid_types: [
+    { annotations: required::["foo", bar] },
+  ]
+}
+$test::{
+  description: "annotations (simplified) list must not be null",
+  invalid_types: [
+    { annotations: required::null.list },
+  ]
+}

--- a/ion_schema_2_0/constraints/annotations-standard.isl
+++ b/ion_schema_2_0/constraints/annotations-standard.isl
@@ -1,0 +1,83 @@
+$ion_schema_2_0
+
+type::{
+  name: only_vowels,
+  regex: "^[aeiouAEIOU]*$"
+}
+
+type::{
+  name: 'annotations: { element: only_vowels }',
+  annotations: { element: only_vowels },
+}
+
+$test::{
+  type: 'annotations: { element: only_vowels }',
+  should_accept_as_valid: [
+    0,
+    ''::0,
+    a::1,
+    aaiie::2.0,
+    OieAiU::Eiie::3e0,
+    a::e::i::o::u::A::E::I::O::U::'4',
+  ],
+  should_reject_as_invalid: [
+    abc::1,
+    a::b::2,
+    $a::3,
+    _e::4,
+    '🥧'::5
+  ],
+}
+
+type::{
+  // Important use case—exactly N annotations allowed
+  name: 'annotations: { container_length: 1 }',
+  annotations: { container_length: 1 },
+}
+
+$test::{
+  type: 'annotations: { container_length: 1 }',
+  should_accept_as_valid: [
+    a::0,
+    $b::1,
+    _c::2,
+    '🥧'::3,
+    ''::4
+  ],
+  should_reject_as_invalid: [
+    1,
+    a::a::2,
+    a::b::2,
+  ],
+}
+
+$test::{
+  description: "annotations argument must not be a sexp",
+  invalid_types: [
+    { annotations: (foo bar) },
+  ]
+}
+$test::{
+  description: "annotations argument must not be a string",
+  invalid_types: [
+    { annotations: "foo" },
+  ]
+}
+$test::{
+  description: "annotations argument type must exist",
+  invalid_types: [
+    { annotations: some_non_existent_type },
+  ]
+}
+$test::{
+  description: "annotations argument must not be a variably occurring type reference",
+  invalid_types: [
+    { annotations: { occurs: optional } },
+  ]
+}
+$test::{
+  description: "annotations argument must not define a type name",
+  invalid_types: [
+    { annotations: { name: foo } },
+  ]
+}

--- a/ion_schema_2_0/constraints/field_names.isl
+++ b/ion_schema_2_0/constraints/field_names.isl
@@ -1,0 +1,127 @@
+$ion_schema_2_0
+
+type::{
+  name: field_names_with_inline_type,
+  field_names: { codepoint_length: range::[1,8] },
+}
+
+$test::{
+  type: field_names_with_inline_type,
+  should_accept_as_valid: [
+    {},
+    { foo: 1, bar: 2 },
+    { hello: 1, world: 2 },
+    { hello: 1, hello: 2 },
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.struct,
+    (),
+    [1, 2.0],
+    1,
+    2d0,
+    3d0,
+    "hello",
+    world,
+    { '': 1 },
+    { a: 1, b: 2, cccccccccccc: 3 },
+    { very_long_field_name: 4 },
+  ],
+}
+
+type::{
+  name: field_names_distinct,
+  field_names: distinct::symbol,
+}
+
+$test::{
+  type: field_names_distinct,
+  should_accept_as_valid: [
+    {},
+    { a: 1 },
+    { a: 1, b: 2 },
+    { a: 1, b: 2, c: 3 },
+  ],
+  should_reject_as_invalid: [
+    null.struct,
+    { a: 1, a: 1 },
+    { a: 1, a: 2 },
+    { a: 1, b: 2, c: 3, a: 4 },
+  ],
+}
+
+type::{
+  name: snake_case,
+  regex: "^[a-z0-9_]*$",
+}
+
+type::{
+  name: field_names_with_type_reference,
+  field_names: snake_case,
+}
+
+$test::{
+  type: field_names_with_type_reference,
+  should_accept_as_valid: [
+    {},
+    { a: 1, b: 2 },
+    { hello: WORLD },
+    { hello_world: 1, hello_world: 2  },
+    { abc_123_def: 1, _foo_bar_baz: 2 },
+  ],
+  should_reject_as_invalid: [
+    null.struct,
+    { A: 1 },
+    { _A: 1, _B: 2 },
+  ],
+}
+
+type::{
+  name: 'field_names: nothing',
+  field_names: nothing,
+}
+
+$test::{
+  type: 'field_names: nothing',
+  should_accept_as_valid: [
+    {},
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.struct,
+    { a: 1 },
+  ],
+}
+
+$test::{
+  description: "field_names must be a type reference",
+  invalid_types: [
+    { field_names: null },
+    { field_names: null.int },
+    { field_names: 5 },
+    { field_names: [int, string] },
+    { field_names: "$int" },
+  ]
+}
+
+$test::{
+  description: "field_names must not be a variably occurring type reference",
+  invalid_types: [
+    { field_names: { occurs: 2, type: int } },
+  ],
+}
+
+$test::{
+  description: "field_names must not be a named type definition",
+  invalid_types: [
+    { field_names: { name: foo, type: int } },
+  ],
+}
+
+$test::{
+  description: "field_names type reference may not have unknown annotations",
+  invalid_types: [
+    { field_names: foo::int },
+    { field_names: distinct::foo::string },
+  ]
+}

--- a/ion_schema_2_0/constraints/fields.isl
+++ b/ion_schema_2_0/constraints/fields.isl
@@ -1,0 +1,214 @@
+$ion_schema_2_0
+
+type::{
+  name: two_optional_fields,
+  fields: { a: bool, b: { occurs: optional, type: int } },
+}
+
+$test::{
+  type: two_optional_fields,
+  should_accept_as_valid: [
+    {},
+    foo::{},
+    { a: true },
+    { a: false },
+    { a: true, b: 1 },
+    { b: 1, c: "foo" },
+    { b: 1 },
+    { c: 1.23, d: [] }
+  ],
+  should_reject_as_invalid: [
+    null.struct,
+    [],
+    (),
+    { a: 1 },
+    { a: null.bool },
+    { a: true, a: true },
+    { a: true, a: false },
+    { b: 1, b: 2 },
+    { b: 1.23 },
+    { a: true, b: "Hello" },
+    { a: "World!", b: 1 },
+  ],
+}
+
+type::{
+  name: one_required_one_optional_fields,
+  fields: { c: { occurs: required, type: int }, d: symbol },
+}
+
+$test::{
+  type: one_required_one_optional_fields,
+  should_accept_as_valid: [
+    { c: 1 },
+    { c: 2, a: true },
+    { c: 1, d: maybe },
+    { b: 1, c: 2 },
+  ],
+  should_reject_as_invalid: [
+    null.struct,
+    {},
+    { c: 1, c: 2 },
+    { c: 1, c: 2, d: foo },
+    { c: 1, d: foo, d: bar },
+    { c: 1, d: null },
+    { c: null, d: foo },
+    { d: hello },
+  ],
+}
+
+type::{
+  name: two_optional_closed_fields,
+  fields: closed::{
+    q: string,
+    a: float,
+  },
+}
+
+$test::{
+  type: two_optional_closed_fields,
+  should_accept_as_valid: [
+    {},
+    { q: "How much do I love Ion Schema?", a: +inf },
+    { q: "What is the airspeed of an unladen swallow?", a: mph::12.5e0 },
+    { a: nan },
+    { q: "Lorem ipsum..." }
+  ],
+  should_reject_as_invalid: [
+    null.struct,
+    { a: 1, b: 1 },
+    { Q: "foo" },
+    { q: "foo", b: 1 },
+    { q: "foo", a: 1d0 },
+    { q: "foo", q: "bar" },
+  ],
+}
+
+type::{
+  name: field_occurs_n_times,
+  fields: {
+    a: { occurs: 3, type: int },
+  },
+}
+
+$test::{
+  type: field_occurs_n_times,
+  should_accept_as_valid: [
+    { a: 1, a: 2, a: 3 },
+    { a: 1, a: 2, a: 3, b: true },
+  ],
+  should_reject_as_invalid: [
+    null.struct,
+    {},
+    { a: 1 },
+    { a: 1, a: 2 },
+    { a: 1, a: 2, a: 3.0 },
+    { a: 1, a: 2, a: 3, a: 4 },
+    { a: 1, a: 2, a: 3, a: 4, a: 5 },
+    { a: 1, a: 2, a: 3, a: 4, a: 5, a: 6 },
+  ],
+}
+
+type::{
+  name: field_occurs_range,
+  fields: closed::{
+    a: { occurs: range::[1, 5], type: int },
+  },
+}
+
+$test::{
+  type: field_occurs_range,
+  should_accept_as_valid: [
+    { a: 1 },
+    { a: 1, a: 2 },
+    { a: 1, a: 2, a: 3 },
+    { a: 1, a: 2, a: 3, a: 4 },
+    { a: 1, a: 2, a: 3, a: 4, a: 5 },
+  ],
+  should_reject_as_invalid: [
+    null.struct,
+    {},
+    { a: true },
+    { b: true },
+    { a: 1, a: 2, a: 3, a: 4, a: 5, a: 6 },
+  ],
+}
+
+type::{
+  name: field_is_nothing,
+  fields: { a: nothing },
+}
+
+$test::{
+  type: field_is_nothing,
+  should_accept_as_valid: [
+    {},
+    { b: 1 }
+  ],
+  should_reject_as_invalid: [
+    null.struct,
+    { a: true },
+  ],
+}
+
+$test::{
+  description: "fields must be a non-null struct",
+  invalid_types: [
+    { fields: null },
+    { fields: null.struct },
+    { fields: range::[1, 5] },
+    { fields: [foo, bar] },
+    { fields: (x + y) },
+    { fields: foo },
+    { fields: "bar" },
+    { fields: 1 },
+    { fields: false },
+  ]
+}
+
+$test::{
+  description: "a field must have a type reference",
+  invalid_types: [
+    { fields: { a: null } },
+    { fields: { a: null.int } },
+    { fields: { a: 5 } },
+    { fields: { a: [int, string] } },
+    { fields: { a: "$int" } },
+  ]
+}
+
+$test::{
+  description: "fields must define at least one field name",
+  invalid_types: [
+    { fields: {} },
+  ],
+}
+
+$test::{
+  description: "fields occurs cannot be 0",
+  invalid_types: [
+    { fields: { a: { occurs: 0 } } },
+  ],
+}
+
+$test::{
+  description: "fields must not define a field twice",
+  invalid_types:[
+    { fields: { a: int, a: bool } },
+    { fields: { a: int, a: int } },
+  ]
+}
+
+$test::{
+  description: "fields struct must not have unknown annotations",
+  invalid_types: [
+    { fields: foo::{ a: any } },
+  ],
+}
+
+$test::{
+  description: "field must not be a named type definition",
+  invalid_types: [
+    { fields: { a: { name: foo, type: int } } },
+  ],
+}

--- a/ion_schema_2_0/constraints/ordered_elements.isl
+++ b/ion_schema_2_0/constraints/ordered_elements.isl
@@ -1,0 +1,252 @@
+$ion_schema_2_0
+
+type::{
+  name: ordered_elements_all_required,
+  ordered_elements: [
+    symbol,
+    int,
+    bool,
+  ]
+}
+
+$test::{
+  type: ordered_elements_all_required,
+  should_accept_as_valid: [
+    [hi, 1, false],
+    (foo 2 true),
+    document::(
+      $foo_bar
+      123
+      false
+    )
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.list,
+    null.sexp,
+    [],
+    [hi, /*1,*/ false],
+    [/*hi,*/ 1, false],
+    [hi, 1 /*,false*/],
+    [hi, "1", false],
+    ["hi", 1, false],
+    [hi, 1, "false"],
+    [hi, hi, 1, false],
+    [hi, 1, 1, false],
+    [hi, 1, false, false],
+    {a: hi, b: 1, c: false},
+    foo,
+    123,
+    true,
+    2022-03-04T,
+    1.23,
+    1.23e4,
+  ]
+}
+
+type::{
+  name: ordered_elements_all_optional,
+  ordered_elements: [
+    { occurs: optional, type: symbol },
+    { occurs: optional, type: int },
+    { occurs: optional, type: bool },
+  ]
+}
+
+$test::{
+  type: ordered_elements_all_optional,
+  should_accept_as_valid: [
+    (foo 2 true),
+    document::(
+      $foo_bar
+      123
+      false
+    ),
+    [],
+    [hi],
+    [1],
+    [false],
+    [hi, 1],
+    [hi, false],
+    [1, false],
+    [hi, 1, false],
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.list,
+    null.sexp,
+    [hi, "1", false],
+    ["hi", 1, false],
+    [hi, 1, "false"],
+    [hi, hi, 1, false],
+    [hi, 1, 1, false],
+    [hi, 1, false, false],
+    {a: hi, b: 1, c: false},
+    foo,
+    123,
+    true,
+    2022-03-04T,
+    1.23,
+    1.23e4,
+  ]
+}
+
+type::{
+  name: ordered_elements_all_at_least_once,
+  ordered_elements: [
+    { occurs: range::[1, max], type: symbol },
+    { occurs: range::[1, max], type: int },
+    { occurs: range::[1, max], type: bool },
+  ]
+}
+
+$test::{
+  type: ordered_elements_all_at_least_once,
+  should_accept_as_valid: [
+    (foo 2 true),
+    document::(
+    $foo_bar
+      123
+      false
+    ),
+    [hi, 1, false],
+    [hi, hi, 1, false],
+    [hi, hi, hi, 1, false],
+    [hi, 1, 1, false],
+    [hi, 1, 1, 1, false],
+    [hi, 1, false, false],
+    [hi, 1, false, false, false],
+    [hi, hi, hi, 1, 1, 1, false, false, false],
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.list,
+    null.sexp,
+    [],
+    [hi],
+    [1],
+    [false],
+    [hi, 1],
+    [hi, false],
+    [1, false],
+    [hi, "1", false],
+    ["hi", 1, false],
+    [hi, 1, "false"],
+    {a: hi, b: 1, c: false},
+    foo,
+    123,
+    true,
+    2022-03-04T,
+    1.23,
+    1.23e4,
+  ]
+}
+
+type::{
+  name: ordered_elements_ambiguous_matches,
+  ordered_elements:[
+    { type: int, occurs: optional },
+    { type: number, occurs: optional },
+    { type: any, occurs: required}
+  ]
+}
+
+$test::{
+  type: ordered_elements_ambiguous_matches,
+  should_accept_as_valid: [
+    [ 1 ],
+    [ 1, 2 ],
+    [ 1, 2, 3 ],
+    [ 1, 2.0 ],
+    [ 1, foo ],
+    [ 1.0, foo ],
+    [ 1, 2.0, foo ],
+    [ foo ],
+    [ 2.0 ],
+    [ 2022-03-04 ],
+  ],
+  should_reject_as_invalid: [
+    [1, 2, 3, 4 ],
+    [1, foo, foo ],
+    [1, foo, 1 ],
+    [1, foo, 1.0 ],
+    [1.0, 1, foo ],
+  ]
+}
+
+type::{
+  name: ordered_elements_mixed_optional,
+  ordered_elements: [
+    { type: bool, occurs: required },
+    { type: int, occurs: optional },
+    { type: decimal, occurs: optional },
+    { type: float, occurs: optional },
+    { type: symbol, occurs: required },
+    { type: bool, occurs: required },
+  ],
+}
+
+$test::{
+  type: ordered_elements_mixed_optional,
+  should_accept_as_valid: [
+    [true, hello, false],
+    [true, 1, hello, false],
+    [true, 2.0, hello, false],
+    [true, 3e0, hello, false],
+    [true, 1, 2.0, hello, false],
+    [true, 1, 3e0, hello, false],
+    [true, 2.0, 3e0, hello, false],
+    [true, 1, 2.0, 3e0, hello, false],
+    (true hello false),
+    document::(true hello false),
+  ],
+  should_reject_as_invalid: [
+    (true hello),
+    (true {}),
+    (true {} true),
+    [1, 2.0, 3e0, hello, false],
+    [true, 1, 2.0, 3e0, false],
+    [true, 1, 2.0, 3e0, hello],
+    document::(true hello),
+    document::(true false),
+    document::(hello false),
+  ],
+}
+
+type::{
+  name: ordered_elements_empty_list,
+  ordered_elements: [],
+}
+
+$test::{
+  type: ordered_elements_empty_list,
+  should_accept_as_valid: [
+    [],
+    (),
+    document::(),
+  ],
+  should_reject_as_invalid: [
+    null.list,
+    null.sexp,
+    {},
+    (1 2 3),
+    [a, b, c],
+    document::(null false true),
+  ],
+}
+
+$test::{
+  description: "ordered_elements must be a list of variably occuring type references",
+  invalid_types: [
+    { ordered_elements: null, },
+    { ordered_elements: null.list },
+    { ordered_elements: () },
+    { ordered_elements: { any_of: [int, string, symbol] } },
+    { ordered_elements: true },
+    { ordered_elements: 3 },
+    { ordered_elements: int },
+    { ordered_elements: (int string symbol) },
+    { ordered_elements: range::[1, 2] },
+    { ordered_elements: range::[int, string] },
+  ],
+}


### PR DESCRIPTION
**Issue #, if available:**

#32 

**Description of changes:**

Adds test cases for `annotations`, `field_names`, `fields`, `ordered_elements` constraints.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
