### PR TITLE
Adds Ion Schema 2.0 test cases for regex constraint

### DIFF
--- a/ion_schema_2_0/constraints/regex-invalid.isl
+++ b/ion_schema_2_0/constraints/regex-invalid.isl
@@ -70,7 +70,7 @@ $test::{
 }
 
 $test::{
-  description: "reluctant quantifiers are not allowed [1]",
+  description: "reluctant quantifiers are not allowed",
   invalid_types: [
     { regex: "abc??" },
     { regex: "abc*?" },

--- a/ion_schema_2_0/constraints/regex-invalid.isl
+++ b/ion_schema_2_0/constraints/regex-invalid.isl
@@ -1,0 +1,101 @@
+$ion_schema_2_0
+
+$test::{
+  description: "Regex must be a non-null string",
+  invalid_types: [
+    { regex: null },
+    { regex: null.string },
+    { regex: 5 },
+    { regex: [] },
+    { regex: () },
+    { regex: {} },
+  ]
+}
+
+$test::{
+  description: "Regex must not have unknown modifier annotations",
+  invalid_types: [
+    { regex: ''::"foo" },
+    { regex: F::"foo" },
+    { regex: M::"foo" },
+    { regex: I::"foo" },
+    { regex: mi::"foo" },
+    { regex: m::I::"foo" },
+    { regex: '🥧'::"foo" },
+  ]
+}
+
+$test::{
+  description: "Backreferences are not allowed",
+  invalid_types: [
+    { regex: "\\1" },
+  ]
+}
+
+$test::{
+  description: "POSIX character classes are not allowed",
+  invalid_types: [
+    { regex: "\\p{Lower}" },
+  ]
+}
+
+$test::{
+  description: "Invalid escaped character",
+  invalid_types: [
+    { regex: "\\A" },
+    { regex: "\\b" },
+    { regex: "\\B" },
+    { regex: "\\c" },
+    { regex: "\\e" },
+    { regex: "\\E" },
+    { regex: "\\G" },
+    { regex: "\\h" },
+    { regex: "\\H" },
+    { regex: "\\R" },
+    { regex: "\\v" },
+    { regex: "\\V" },
+    { regex: "\\Q" },
+    { regex: "\\Z" },
+    { regex: "\\z" },
+  ]
+}
+
+$test::{
+  description: "invalid character classes/ranges",
+  invalid_types: [
+    { regex: "[a-d[m-p]]" },
+    { regex: "[a-z&&[def]]" },
+    { regex: "[\\p{L}]" },
+  ]
+}
+
+$test::{
+  description: "reluctant quantifiers are not allowed [1]",
+  invalid_types: [
+    { regex: "abc??" },
+    { regex: "abc*?" },
+    { regex: "abc+?" },
+    { regex: "abc{1}?" },
+    { regex: "abc{1,}?" },
+    { regex: "abc{1,2}?" },
+  ]
+}
+
+$test::{
+  description: "possessive quantifiers are not allowed",
+  invalid_types: [
+    { regex: "abc?+" },
+    { regex: "abc*+" },
+    { regex: "abc++" },
+    { regex: "abc{1}+" },
+    { regex: "abc{1,}+" },
+    { regex: "abc{1,2}+" },
+  ]
+}
+
+$test::{
+  description: '''special constructs with prefix "(?" are not allowed''',
+  invalid_types:[
+    { regex: "(?" }
+  ],
+}

--- a/ion_schema_2_0/constraints/regex-invalid.isl
+++ b/ion_schema_2_0/constraints/regex-invalid.isl
@@ -1,14 +1,28 @@
 $ion_schema_2_0
 
 $test::{
-  description: "Regex must be a non-null string",
+  description: "Regex must be non-null",
   invalid_types: [
     { regex: null },
     { regex: null.string },
+  ]
+}
+
+$test::{
+  description: "Regex must be a string",
+  invalid_types: [
+    { regex: 'abc.*' },
     { regex: 5 },
     { regex: [] },
     { regex: () },
     { regex: {} },
+  ]
+}
+
+$test::{
+  description: "Regex must be a non-empty string",
+  invalid_types: [
+    { regex: "" },
   ]
 }
 
@@ -91,6 +105,13 @@ $test::{
     { regex: "abc{1,}+" },
     { regex: "abc{1,2}+" },
   ]
+}
+
+$test::{
+  description: "quantifier must have an explicit lower bound",
+  invalid_types:[
+    { regex: "a{,2}", }
+  ],
 }
 
 $test::{

--- a/ion_schema_2_0/constraints/regex.isl
+++ b/ion_schema_2_0/constraints/regex.isl
@@ -1,0 +1,1091 @@
+$ion_schema_2_0
+
+type::{
+  name: regex_alternation,
+  regex: "ab|cd|ef",
+}
+$test::{
+  type: regex_alternation,
+  should_accept_as_valid: [
+    "ab",
+    "cd",
+    "ef",
+  ],
+  should_reject_as_invalid: [
+    "a",
+    "ac",
+    "ace",
+    "bdf",
+  ]
+}
+
+type::{
+  name: regex_boundary_line_begin,
+  regex: "^abc",
+}
+$test::{
+  type: regex_boundary_line_begin,
+  should_accept_as_valid: [
+    "abc",
+  ],
+  should_reject_as_invalid: [
+    " abc",
+  ]
+}
+
+type::{
+  name: regex_boundary_line_end,
+  regex: "abc$",
+}
+$test::{
+  type: regex_boundary_line_end,
+  should_accept_as_valid: [
+    "abc",
+  ],
+  should_reject_as_invalid: [
+    "abc ",
+  ]
+}
+
+type::{
+  name: regex_case_insensitive,
+  regex: i::"hello",
+}
+$test::{
+  type: regex_case_insensitive,
+  should_accept_as_valid: [
+    hello,
+    HellO,
+    "hello",
+    "HELLO",
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.null,
+    null.string,
+    null.symbol,
+    null.bool,
+    '',
+    "",
+    'goodbye',
+  ]
+}
+
+type::{
+  name: regex_case_sensitive,
+  regex: "hello",
+}
+$test::{
+  type: regex_case_sensitive,
+  should_accept_as_valid: [
+    hello,
+    "hello",
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.null,
+    null.string,
+    null.symbol,
+    null.bool,
+    '',
+    "",
+    HellO,
+    "HELLO",
+  ]
+}
+
+type::{
+  name: regex_character_any,
+  regex: "^.$",
+}
+$test::{
+  type: regex_character_any,
+  should_accept_as_valid: [
+    "a",
+    "B",
+    "9",
+    "😊",
+  ],
+  should_reject_as_invalid: [
+    null,
+    "",
+    "\n",
+    "\r",
+  ]
+}
+
+type::{
+  name: regex_character_class_compound_negated,
+  regex: "[^ac-eh-jmnt-vz]",
+}
+$test::{
+  type: regex_character_class_compound_negated,
+  should_accept_as_valid: [
+    "b",
+    "f",
+    "g",
+    "k",
+    "l",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "w",
+    "x",
+    "y",
+  ],
+  should_reject_as_invalid: [
+    "a",
+    "c",
+    "d",
+    "e",
+    "h",
+    "i",
+    "j",
+    "m",
+    "n",
+    "t",
+    "u",
+    "v",
+    "z",
+  ]
+}
+
+type::{
+  name: regex_character_class_dot,
+  regex: "[.]",
+}
+$test::{
+  type: regex_character_class_dot,
+  should_accept_as_valid: [
+    '.',
+    ".",
+  ],
+  should_reject_as_invalid: [
+    'a',
+    "a",
+  ]
+}
+
+type::{
+  name: regex_character_class_escape_chars,
+  regex: "[\\[\\]\\\\]",
+}
+$test::{
+  type: regex_character_class_escape_chars,
+  should_accept_as_valid: [
+    "[",
+    "]",
+    "\\", //"// <-- This extra comment markers and quote is to stop intellij from messing up the code formatting. https://github.com/amzn/ion-intellij-plugin/issues/40
+  ],
+  should_reject_as_invalid: [
+    "a",
+    ".",
+  ]
+}
+
+type::{
+  name: regex_character_class_negated,
+  regex: "[^bcd]",
+}
+$test::{
+  type: regex_character_class_negated,
+  should_accept_as_valid: [
+    "a",
+    "e",
+  ],
+  should_reject_as_invalid: [
+    "b",
+    "c",
+    "d",
+  ]
+}
+
+type::{
+  name: regex_character_class_special_chars,
+  regex: "[\0\a\b\t\n\v\f\r]",
+}
+$test::{
+  type: regex_character_class_special_chars,
+  should_accept_as_valid: [
+    "\0",
+    "\a",
+    "\b",
+    "\t",
+    "\n",
+    "\v",
+    "\f",
+    "\r",
+  ],
+  should_reject_as_invalid: [
+    "a",
+    ".",
+  ]
+}
+
+type::{
+  name: regex_character_class_word_char,
+  regex: "[A-Za-z0-9]",
+}
+$test::{
+  type: regex_character_class_word_char,
+  should_accept_as_valid: [
+    "A",
+    "M",
+    "Z",
+    "a",
+    "n",
+    "z",
+    "0",
+    "5",
+    "9",
+  ],
+  should_reject_as_invalid: [
+    " ",
+    ".",
+    "\t",
+    "#",
+    "~",
+  ]
+}
+
+type::{
+  name: regex_character_class,
+  regex: "[bcd]",
+}
+$test::{
+  type: regex_character_class,
+  should_accept_as_valid: [
+    "b",
+    "c",
+    "d",
+  ],
+  should_reject_as_invalid: [
+    "a",
+    "e",
+  ]
+}
+
+type::{
+  name: regex_character_range_negated,
+  regex: "[^b-g]",
+}
+$test::{
+  type: regex_character_range_negated,
+  should_accept_as_valid: [
+    "a",
+    "i",
+  ],
+  should_reject_as_invalid: [
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+  ]
+}
+
+type::{
+  name: regex_character_range,
+  regex: "[b-g]",
+}
+$test::{
+  type: regex_character_range,
+  should_accept_as_valid: [
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+  ],
+  should_reject_as_invalid: [
+    "a",
+    "i",
+  ]
+}
+
+type::{
+  name: regex_complex_nested_quantified_alternation,
+  regex: "^(ab|(cd){2,3}|ef){2}$",
+}
+$test::{
+  type: regex_complex_nested_quantified_alternation,
+  should_accept_as_valid: [
+    abab,
+    abcdcd,
+    abcdcdcd,
+    abef,
+    cdcdab,
+    cdcdcdab,
+    cdcdcdcd,
+    cdcdcdcdcd,
+    cdcdcdcdcdcd,
+    cdcdcdef,
+    cdcdef,
+    efab,
+    efcdcd,
+    efcdcdcd,
+    efef,
+  ],
+  should_reject_as_invalid: [
+    "",
+    ab,
+    abcdcdcdcd,
+    cd,
+    cdcd,
+    cdcdcd,
+    cdcdcdcdcdcdcd,
+    cdcdcdcdef,
+    ef,
+  ]
+}
+
+type::{
+  name: regex_escape_characters,
+  // There is an space at the end of this regex because the Ion plugin doesn't handle escaped backsalshes at the end
+  // of a string correctly. See https://github.com/amzn/ion-intellij-plugin/issues/40.
+  regex: "\\.\\^\\$\\|\\?\\*\\+\\[\\]\\(\\)\\{\\}\\\\ ",
+}
+$test::{
+  type: regex_escape_characters,
+  should_accept_as_valid: [
+    '.^$|?*+[](){}\\ ',
+    ".^$|?*+[](){}\\ ",
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.null,
+    null.string,
+    null.symbol,
+    null.bool,
+    'hello world',
+    "hello world",
+  ]
+}
+
+type::{
+  name: regex_escape_double_quote,
+  regex: "\"free\"",
+}
+$test::{
+  type: regex_escape_double_quote,
+  should_accept_as_valid: [
+    '"free"',
+    "\"free\"",
+    'Totally "free" food!',
+    "Totally \"free\" food!",
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.null,
+    null.string,
+    null.symbol,
+    null.bool,
+    '',
+    "",
+    'free',
+    "free",
+  ]
+}
+
+type::{
+  name: regex_escape_forwardslash,
+  regex: "a/b",
+}
+$test::{
+  type: regex_escape_forwardslash,
+  should_accept_as_valid: [
+    'a/b',
+    "a/b",
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.null,
+    null.string,
+    null.symbol,
+    null.bool,
+    '',
+    "",
+    ab,
+    "ab",
+  ]
+}
+
+type::{
+  name: regex_escape_single_quote,
+  regex: "it's",
+}
+$test::{
+  type: regex_escape_single_quote,
+  should_accept_as_valid: [
+    'it\'s',
+    "it's",
+    'I can\'t believe it\'s not butter!',
+    "I can't believe it's not butter!",
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.null,
+    null.string,
+    null.symbol,
+    null.bool,
+    '',
+    "",
+    its,
+    "its",
+  ]
+}
+
+type::{
+  name: regex_escape_tab,
+  regex: "hello\tworld",
+}
+$test::{
+  type: regex_escape_tab,
+  should_accept_as_valid: [
+    'hello\tworld',
+    'hello	world',
+    "hello\tworld",
+    "hello	world",
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.null,
+    null.string,
+    null.symbol,
+    null.bool,
+    'hello world',
+    "hello world",
+  ]
+}
+
+type::{
+  name: regex_unescaped_tab,
+  // There is an unescaped tab character in this regex
+  regex: "hello	world",
+}
+$test::{
+  type: regex_unescaped_tab,
+  should_accept_as_valid: [
+    'hello\tworld',
+    'hello	world',
+    "hello\tworld",
+    "hello	world",
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.null,
+    null.string,
+    null.symbol,
+    null.bool,
+    'hello world',
+    "hello world",
+  ]
+}
+
+type::{
+  name: regex_grouping,
+  regex: "123(ab|cd|ef)456",
+}
+$test::{
+  type: regex_grouping,
+  should_accept_as_valid: [
+    "123ab456",
+    "123cd456",
+    "123ef456",
+  ],
+  should_reject_as_invalid: [
+    "123a456",
+    "123ac456",
+    "123ace456",
+    "123bdf456",
+  ]
+}
+
+type::{
+  name: regex_ion_escape_characters,
+  regex: "\0\a\b\t\n\f\r\v",
+}
+$test::{
+  type: regex_ion_escape_characters,
+  should_accept_as_valid: [
+    '\0\a\b\t\n\f\r\v',
+    "\0\a\b\t\n\f\r\v",
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.null,
+    null.string,
+    null.symbol,
+    null.bool,
+    'hello world',
+    "hello world",
+  ]
+}
+
+type::{
+  name: regex_multiline,
+  regex: m::"^hello world$",
+}
+$test::{
+  type: regex_multiline,
+  should_accept_as_valid: [
+    'hello world',
+    'hello world\n\n\n',
+    '\n\n\nhello world',
+    '\n\n\nhello world\n\n\n',
+    '\r\r\rhello world\r\r\r',
+
+    "hello world",
+    "hello world\n\n\n",
+    "\n\n\nhello world",
+    "\n\n\nhello world\n\n\n",
+    "\r\r\rhello world\r\r\r",
+  ],
+  should_reject_as_invalid: [
+    null,
+    null.null,
+    null.string,
+    null.symbol,
+    null.bool,
+    " hello world",
+    "hello world ",
+    "\n hello world",
+    "hello world \n",
+    "hello\n world",
+    "hello \nworld",
+    "hello\r world",
+    "hello \rworld",
+  ]
+}
+
+type::{
+  name: regex_predefined_character_class_digit,
+  regex: "\\d",
+}
+$test::{
+  type: regex_predefined_character_class_digit,
+  should_accept_as_valid: [
+    "0",
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+  ],
+  should_reject_as_invalid: [
+    "/",
+    ":",
+  ]
+}
+
+type::{
+  name: regex_predefined_character_class_non_digit,
+  regex: "\\D",
+}
+$test::{
+  type: regex_predefined_character_class_non_digit,
+  should_accept_as_valid: [
+    "/",
+    ":",
+  ],
+  should_reject_as_invalid: [
+    "0",
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+  ]
+}
+
+type::{
+  name: regex_predefined_character_class_non_whitespace,
+  regex: "\\S",
+}
+$test::{
+  type: regex_predefined_character_class_non_whitespace,
+  should_accept_as_valid: [
+    "\0",
+    "\b",
+    "\v",
+    "a",
+    "9",
+  ],
+  should_reject_as_invalid: [
+    " ",
+    "\f",
+    "\n",
+    "\r",
+    "\t",
+  ]
+}
+
+type::{
+  name: regex_predefined_character_class_non_word,
+  regex: "\\W",
+}
+$test::{
+  type: regex_predefined_character_class_non_word,
+  should_accept_as_valid: [
+    "/",
+    ":",
+    "@",
+    "[",
+    "`",
+    "{",
+  ],
+  should_reject_as_invalid: [
+    "a",
+    "A",
+    "z",
+    "Z",
+    "0",
+    "9",
+  ]
+}
+
+type::{
+  name: regex_predefined_character_class_whitespace,
+  regex: "\\s",
+}
+$test::{
+  type: regex_predefined_character_class_whitespace,
+  should_accept_as_valid: [
+    " ",
+    "\f",
+    "\n",
+    "\r",
+    "\t",
+  ],
+  should_reject_as_invalid: [
+    "\0",
+    "\b",
+    "\v",
+    "a",
+    "9",
+  ]
+}
+
+type::{
+  name: regex_predefined_character_class_word,
+  regex: "\\w",
+}
+$test::{
+  type: regex_predefined_character_class_word,
+  should_accept_as_valid: [
+    "a",
+    "A",
+    "z",
+    "Z",
+    "0",
+    "9",
+    "_",
+  ],
+  should_reject_as_invalid: [
+    "/",
+    ":",
+    "@",
+    "[",
+    "`",
+    "{",
+    "-",
+  ]
+}
+
+type::{
+  name: regex_character_class_compound,
+  regex: "[ac-eh-jmnt-vz]",
+}
+$test::{
+  type: regex_character_class_compound,
+  should_accept_as_valid: [
+    "a",
+    "c",
+    "d",
+    "e",
+    "h",
+    "i",
+    "j",
+    "m",
+    "n",
+    "t",
+    "u",
+    "v",
+    "z",
+  ],
+  should_reject_as_invalid: [
+    "b",
+    "f",
+    "g",
+    "k",
+    "l",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "w",
+    "x",
+    "y",
+  ]
+}
+
+type::{
+  name: regex_character_class_unioned_with_d_metachar_class,
+  regex: "[a-f\\d]",
+}
+$test::{
+  type: regex_character_class_unioned_with_d_metachar_class,
+  should_accept_as_valid: [
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "0",
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+  ],
+  should_reject_as_invalid: [
+    "g",
+    "h",
+    "i",
+    "j",
+    "k",
+    "l",
+    "m",
+    "n",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "t",
+    "u",
+    "v",
+    "w",
+    "x",
+    "y",
+    "z",
+    "A",
+    " ",
+  ]
+}
+
+type::{
+  name: regex_character_class_unioned_with_D_metachar_class,
+  regex: "[0\\D]",
+}
+$test::{
+  type: regex_character_class_unioned_with_D_metachar_class,
+  should_accept_as_valid: [
+    "0",
+    "a",
+    "B",
+    "[",
+    "}",
+    "π",
+    " ",
+    "\n",
+    ".",
+    "@",
+    "🤨",
+  ],
+  should_reject_as_invalid: [
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+  ]
+}
+
+type::{
+  name: regex_character_class_unioned_with_w_metachar_class,
+  regex: "[@\\w]",
+}
+$test::{
+  type: regex_character_class_unioned_with_w_metachar_class,
+  should_accept_as_valid: [
+    "0",
+    "1",
+    "2",
+    "3",
+    "a",
+    "b",
+    "c",
+    "D",
+    "E",
+    "F",
+    "_",
+    "@",
+  ],
+  should_reject_as_invalid: [
+    "}",
+    "π",
+    " ",
+    "\n",
+    "\t",
+    "\b",
+    ".",
+    "#",
+    "🤨",
+  ]
+}
+
+type::{
+  name: regex_character_class_unioned_with_W_metachar_class,
+  regex: "[abc\\W]",
+}
+$test::{
+  type: regex_character_class_unioned_with_W_metachar_class,
+  should_accept_as_valid: [
+    "a",
+    "b",
+    "c",
+    "[",
+    "}",
+    "π",
+    " ",
+    "\n",
+    ".",
+    "@",
+    "🤨",
+  ],
+  should_reject_as_invalid: [
+    "0",
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "d",
+    "e",
+    "f",
+    "A",
+    "B",
+    "C",
+    "_",
+  ]
+}
+
+type::{
+  name: regex_character_class_unioned_with_s_metachar_class,
+  regex: "[abc\\s]",
+}
+$test::{
+  type: regex_character_class_unioned_with_s_metachar_class,
+  should_accept_as_valid: [
+    "a",
+    "b",
+    "c",
+    " ",
+    "\f",
+    "\r",
+    "\t",
+    "\n",
+  ],
+  should_reject_as_invalid: [
+    "0",
+    "1",
+    "2",
+    "3",
+    "}",
+    "π",
+    ".",
+    "@",
+    "🤨",
+    "\b",
+  ]
+}
+
+type::{
+  name: regex_character_class_unioned_with_S_metachar_class,
+  regex: "[ \\S]",
+}
+$test::{
+  type: regex_character_class_unioned_with_S_metachar_class,
+  should_accept_as_valid: [
+    "0",
+    "a",
+    "B",
+    "[",
+    "}",
+    "π",
+    ".",
+    "@",
+    "🤨",
+    "\b",
+    " ",
+  ],
+  should_reject_as_invalid: [
+    "\f",
+    "\n",
+    "\r",
+    "\t",
+  ]
+}
+
+type::{
+  name: regex_quantifier_at_least_n,
+  regex: "ab{3,}c",
+}
+$test::{
+  type: regex_quantifier_at_least_n,
+  should_accept_as_valid: [
+    "abbbc",
+    "abbbbc",
+    "abbbbbc",
+  ],
+  should_reject_as_invalid: [
+    "ac",
+    "abc",
+    "abbc",
+  ]
+}
+
+type::{
+  name: regex_quantifier_exactly_n,
+  regex: "ab{3}c",
+}
+$test::{
+  type: regex_quantifier_exactly_n,
+  should_accept_as_valid: [
+    "abbbc",
+  ],
+  should_reject_as_invalid: [
+    "abbc",
+    "abbbbc",
+  ]
+}
+
+type::{
+  name: regex_quantifier_one_to_many,
+  regex: "ab+c",
+}
+$test::{
+  type: regex_quantifier_one_to_many,
+  should_accept_as_valid: [
+    "abc",
+    "abbc",
+    "abbbc",
+  ],
+  should_reject_as_invalid: [
+    "ac",
+  ]
+}
+
+type::{
+  name: regex_quantifier_range,
+  regex: "ab{3,6}c",
+}
+$test::{
+  type: regex_quantifier_range,
+  should_accept_as_valid: [
+    "abbbc",
+    "abbbbc",
+    "abbbbbc",
+    "abbbbbbc",
+  ],
+  should_reject_as_invalid: [
+    "abbc",
+    "abbbbbbbc",
+  ]
+}
+
+type::{
+  name: regex_quantifier_zero_or_one,
+  regex: "ab?c",
+}
+$test::{
+  type: regex_quantifier_zero_or_one,
+  should_accept_as_valid: [
+    "ac",
+    "abc",
+  ],
+  should_reject_as_invalid: [
+    "abbc",
+  ]
+}
+
+type::{
+  name: regex_quantifier_zero_to_many,
+  regex: "ab*c",
+}
+$test::{
+  type: regex_quantifier_zero_to_many,
+  should_accept_as_valid: [
+    "ac",
+    "abc",
+    "abbc",
+    "abbbc",
+  ],
+  should_reject_as_invalid: [
+    "",
+    "ab",
+    "bc",
+  ]
+}
+
+type::{
+  name: regex_special_characters,
+  regex: "\0\a\b\t\n\v\f\r",
+}
+$test::{
+  type: regex_special_characters,
+  should_accept_as_valid: [
+    '\0\a\b\t\n\v\f\r',
+    "\0\a\b\t\n\v\f\r",
+  ],
+  should_reject_as_invalid: [
+    a,
+    "A",
+  ]
+}
+
+type::{
+  name: regex_unicode_emoji,
+  regex: "^[😀\U0001f642😊]{3,6}$",
+}
+$test::{
+  type: regex_unicode_emoji,
+  should_accept_as_valid: [
+    "😊😀🙂",
+    "🙂🙂🙂🙂",
+    "😊😊😊😊😊",
+    "😊😀🙂😊😀🙂",
+    "\U0001f600\U0001f600\U0001f600",
+  ],
+  should_reject_as_invalid: [
+    "😊😀",
+    "😊😀🙂😊😀🙂😊",
+  ]
+}

--- a/ion_schema_2_0/constraints/regex.isl
+++ b/ion_schema_2_0/constraints/regex.isl
@@ -1,23 +1,187 @@
 $ion_schema_2_0
 
 type::{
-  name: regex_alternation,
-  regex: "ab|cd|ef",
+  name: regex_should_accept_non_null_text,
+  regex: ".*",
 }
 $test::{
-  type: regex_alternation,
+  type: regex_should_accept_non_null_text,
   should_accept_as_valid: [
-    "ab",
-    "cd",
-    "ef",
+    '',
+    abc,
+    "",
+    "abc",
+    foo::"def",
   ],
   should_reject_as_invalid: [
-    "a",
-    "ac",
-    "ace",
-    "bdf",
+    null,
+    null.string,
+    null.symbol,
+    ["a", "b"],
+    (a b c),
+    123,
+    2022-01-01T,
+    {{ "abc" }},
   ]
 }
+
+// Test cases for different types of characters
+
+type::{
+  name: regex_character_any,
+  regex: "^.$",
+}
+$test::{
+  type: regex_character_any,
+  should_accept_as_valid: [
+    "a",
+    "B",
+    "9",
+    "😊",
+    '\'',
+    "'",
+    "/",
+    "@",
+  ],
+  should_reject_as_invalid: [
+    "",
+    "\n",
+    "\r",
+  ]
+}
+
+type::{
+  name: regex_ion_escape_characters,
+  regex: "\0\a\b\t\n\v\f\r",
+}
+$test::{
+  type: regex_ion_escape_characters,
+  should_accept_as_valid: [
+    '\0\a\b\t\n\v\f\r',
+    "\0\a\b\t\n\v\f\r",
+  ],
+  should_reject_as_invalid: [
+    a,
+    "A",
+  ]
+}
+
+type::{
+  name: regex_unicode_emoji,
+  regex: "^[😀\U0001f642😊]{3,6}$",
+}
+$test::{
+  type: regex_unicode_emoji,
+  should_accept_as_valid: [
+    "😊😀🙂",
+    "🙂🙂🙂🙂",
+    "😊😊😊😊😊",
+    "😊😀🙂😊😀🙂",
+    "\U0001f600\U0001f600\U0001f600",
+  ],
+  should_reject_as_invalid: [
+    "😊😀",
+    "😊😀🙂😊😀🙂😊",
+  ]
+}
+
+type::{
+  name: regex_escape_characters,
+  regex: "\\\\\\.\\^\\$\\|\\?\\*\\+\\[\\]\\(\\)\\{\\}",
+}
+$test::{
+  type: regex_escape_characters,
+  should_accept_as_valid: [
+    '\\.^$|?*+[](){}',
+    "\\.^$|?*+[](){}",
+  ],
+  should_reject_as_invalid: [
+    'hello world',
+    "hello world",
+  ]
+}
+
+type::{
+  name: regex_escape_double_quote,
+  regex: "\"free\"",
+}
+$test::{
+  type: regex_escape_double_quote,
+  should_accept_as_valid: [
+    '"free"',
+    "\"free\"",
+    'Totally "free" food!',
+    "Totally \"free\" food!",
+  ],
+  should_reject_as_invalid: [
+    '',
+    "",
+    'free',
+    "free",
+  ]
+}
+
+type::{
+  name: regex_escape_tab,
+  regex: "hello\tworld",
+}
+$test::{
+  type: regex_escape_tab,
+  should_accept_as_valid: [
+    'hello\tworld',
+    'hello	world',
+    "hello\tworld",
+    "hello	world",
+  ],
+  should_reject_as_invalid: [
+    'hello world',
+    "hello world",
+    "helloworld",
+  ]
+}
+
+type::{
+  name: regex_unescaped_tab,
+  // There is an unescaped tab character in this regex between the two words
+  regex: "hello	world",
+}
+$test::{
+  type: regex_unescaped_tab,
+  should_accept_as_valid: [
+    'hello\tworld',
+    'hello	world',
+    "hello\tworld",
+    "hello	world",
+  ],
+  should_reject_as_invalid: [
+    'hello world',
+    "hello world",
+    "helloworld",
+  ]
+}
+
+type::{
+  name: regex_unescaped_newline,
+  regex: '''hello
+world''',
+}
+$test::{
+  type: regex_unescaped_newline,
+  should_accept_as_valid: [
+    'hello\nworld',
+    '''hello
+world''',
+    "hello\nworld",
+  ],
+  should_reject_as_invalid: [
+    'hello world',
+    "hello world",
+    "hello\rworld",
+    "helloworld",
+  ]
+}
+
+// Anchors
 
 type::{
   name: regex_boundary_line_begin,
@@ -48,6 +212,26 @@ $test::{
 }
 
 type::{
+  name: regex_for_an_empty_string,
+  regex: "^$",
+}
+$test::{
+  type: regex_for_an_empty_string,
+  should_accept_as_valid: [
+    "",
+    '',
+  ],
+  should_reject_as_invalid: [
+    "a",
+    " ",
+    "\0",
+    "\b",
+  ]
+}
+
+// Regex modifiers
+
+type::{
   name: regex_case_insensitive,
   regex: i::"hello",
 }
@@ -60,11 +244,6 @@ $test::{
     "HELLO",
   ],
   should_reject_as_invalid: [
-    null,
-    null.null,
-    null.string,
-    null.symbol,
-    null.bool,
     '',
     "",
     'goodbye',
@@ -82,73 +261,373 @@ $test::{
     "hello",
   ],
   should_reject_as_invalid: [
-    null,
-    null.null,
-    null.string,
-    null.symbol,
-    null.bool,
     '',
     "",
-    HellO,
+    Hello,
     "HELLO",
   ]
 }
 
 type::{
-  name: regex_character_any,
-  regex: "^.$",
+  name: regex_multiline,
+  regex: m::"^hello world$",
 }
 $test::{
-  type: regex_character_any,
+  type: regex_multiline,
   should_accept_as_valid: [
-    "a",
-    "B",
-    "9",
-    "😊",
+    'hello world',
+    'hello world\n',
+    '\nhello world',
+    '\nhello world\n',
+    '\rhello world\r',
+    '\n\r\nhello world\r\n\r',
+    "hello world",
+    "hello world\n",
+    "\nhello world",
+    "\nhello world\n",
+    "\rhello world\r",
+    "\r\n\rhello world\n\r\n",
+    "hello world\ngoodbye world",
+    '''
+greetings earthling
+hello world
+bonjour le monde
+    ''',
   ],
   should_reject_as_invalid: [
-    null,
-    "",
-    "\n",
-    "\r",
+    " hello world",
+    "hello world ",
+    "\n hello world",
+    "hello world \n",
+    "hello\n world",
+    "hello \nworld",
+    "hello\r world",
+    "hello \rworld",
+  ]
+}
+
+// Quantifiers
+
+type::{
+  name: regex_quantifier_zero_or_one,
+  regex: "ab?c",
+}
+$test::{
+  type: regex_quantifier_zero_or_one,
+  should_accept_as_valid: [
+    "ac",
+    "abc",
+  ],
+  should_reject_as_invalid: [
+    "abbc",
   ]
 }
 
 type::{
-  name: regex_character_class_compound_negated,
-  regex: "[^ac-eh-jmnt-vz]",
+  name: regex_quantifier_zero_to_many,
+  regex: "ab*c",
 }
 $test::{
-  type: regex_character_class_compound_negated,
+  type: regex_quantifier_zero_to_many,
   should_accept_as_valid: [
-    "b",
-    "f",
-    "g",
-    "k",
-    "l",
-    "o",
-    "p",
-    "q",
-    "r",
-    "s",
-    "w",
-    "x",
-    "y",
+    "ac",
+    "abc",
+    "abbc",
+    "abbbc",
+  ],
+  should_reject_as_invalid: [
+    "",
+    "ab",
+    "bc",
+  ]
+}
+
+type::{
+  name: regex_quantifier_one_to_many,
+  regex: "ab+c",
+}
+$test::{
+  type: regex_quantifier_one_to_many,
+  should_accept_as_valid: [
+    "abc",
+    "abbc",
+    "abbbc",
+  ],
+  should_reject_as_invalid: [
+    "ac",
+  ]
+}
+
+type::{
+  name: regex_quantifier_exactly_n,
+  regex: "ab{3}c",
+}
+$test::{
+  type: regex_quantifier_exactly_n,
+  should_accept_as_valid: [
+    "abbbc",
+  ],
+  should_reject_as_invalid: [
+    "abbc",
+    "abbbbc",
+  ]
+}
+
+type::{
+  name: regex_quantifier_at_least_n,
+  regex: "ab{3,}c",
+}
+$test::{
+  type: regex_quantifier_at_least_n,
+  should_accept_as_valid: [
+    "abbbc",
+    "abbbbc",
+    "abbbbbc",
+  ],
+  should_reject_as_invalid: [
+    "ac",
+    "abc",
+    "abbc",
+  ]
+}
+
+type::{
+  name: regex_quantifier_at_most_n,
+  regex: "ab{0,2}c",
+}
+$test::{
+  type: regex_quantifier_at_most_n,
+  should_accept_as_valid: [
+    "ac",
+    "abc",
+    "abbc",
+  ],
+  should_reject_as_invalid: [
+    "abbbc",
+    "abbbbc",
+    "abbbbbc",
+  ]
+}
+
+type::{
+  name: regex_quantifier_range,
+  regex: "ab{2,4}c",
+}
+$test::{
+  type: regex_quantifier_range,
+  should_accept_as_valid: [
+    "abbc",
+    "abbbc",
+    "abbbbc",
+  ],
+  should_reject_as_invalid: [
+    "abc",
+    "abbbbbc",
+  ]
+}
+
+// Alternation & Grouping
+
+type::{
+  name: regex_alternation,
+  regex: "ab|cd|ef",
+}
+$test::{
+  type: regex_alternation,
+  should_accept_as_valid: [
+    "ab",
+    "cd",
+    "ef",
   ],
   should_reject_as_invalid: [
     "a",
+    "ac",
+    "bc",
+    "ace",
+    "bdf",
+  ]
+}
+
+type::{
+  name: regex_alternation_with_anchors,
+  regex: "^a|a$",
+}
+$test::{
+  type: regex_alternation_with_anchors,
+  should_accept_as_valid: [
+    "a",
+    "ab",
+    "ba",
+    "aba",
+  ],
+  should_reject_as_invalid: [
+    "",
+    "bab",
+    "b",
+  ]
+}
+
+type::{
+  name: regex_grouping,
+  regex: "123(abc)?456",
+}
+$test::{
+  type: regex_grouping,
+  should_accept_as_valid: [
+    "123abc456",
+    "123456",
+  ],
+  should_reject_as_invalid: [
+    "123a456",
+    "123b456",
+    "123c456",
+    "123ab456",
+    "123ac456",
+    "123bc456",
+  ]
+}
+
+type::{
+  name: regex_alternation_in_group,
+  regex: "^(ab|cd|ef)$",
+}
+$test::{
+  type: regex_alternation_in_group,
+  should_accept_as_valid: [
+    ab,
+    cd,
+    ef
+  ],
+  should_reject_as_invalid: [
+    "",
+    abcd,
+    abef,
+    cdef,
+    abcdef,
+  ]
+}
+
+type::{
+  name: regex_repeated_group,
+  regex: "^(ab)*$",
+}
+$test::{
+  type: regex_repeated_group,
+  should_accept_as_valid: [
+    "",
+    ab,
+    abab,
+    ababab,
+  ],
+  should_reject_as_invalid: [
+    a,
+    ba,
+    aba,
+    abba,
+    ababa,
+  ]
+}
+
+type::{
+  name: regex_group_of_quantified_alternates,
+  regex: "^(a+|b{2})$",
+}
+$test::{
+  type: regex_group_of_quantified_alternates,
+  should_accept_as_valid: [
+    a,
+    aa,
+    aaa,
+    aaaa,
+    bb,
+  ],
+  should_reject_as_invalid: [
+    '',
+    b,
+    bbb,
+    aab,
+    abb,
+  ]
+}
+
+type::{
+  name: regex_quantified_group_of_alternates,
+  regex: "^(a|bc|def){2,3}$",
+}
+$test::{
+  type: regex_quantified_group_of_alternates,
+  should_accept_as_valid: [
+    // Exhaustive for all combos of 2 alternates
+    aa,
+    abc,
+    adef,
+    bca,
+    bcbc,
+    bcdef,
+    defa,
+    defbc,
+    defdef,
+    // Non-exhaustive for combos of 3 alternates
+    aaa,
+    aabc,
+    aadef,
+    abca,
+    adefa,
+    bcbcbc,
+    bcdefbc,
+    bcdefa,
+    defdefdef,
+    defbca,
+  ],
+  should_reject_as_invalid: [
+    '',
+    a,
+    bc,
+    def,
+    aaaa,
+    aaabc,
+    aaadef,
+    abcabc,
+    bcbcbcbc,
+    defdefdefdef,
+    abc0def,
+    acbfed,
+  ]
+}
+
+// Character Classes
+
+type::{
+  name: regex_character_class,
+  regex: "[bcd]",
+}
+$test::{
+  type: regex_character_class,
+  should_accept_as_valid: [
+    "b",
     "c",
     "d",
+  ],
+  should_reject_as_invalid: [
+    "a",
     "e",
-    "h",
-    "i",
-    "j",
-    "m",
-    "n",
-    "t",
-    "u",
-    "v",
-    "z",
+  ]
+}
+
+type::{
+  name: regex_character_class_negated,
+  regex: "[^bcd]",
+}
+$test::{
+  type: regex_character_class_negated,
+  should_accept_as_valid: [
+    "a",
+    "e",
+  ],
+  should_reject_as_invalid: [
+    "b",
+    "c",
+    "d",
   ]
 }
 
@@ -177,28 +656,11 @@ $test::{
   should_accept_as_valid: [
     "[",
     "]",
-    "\\", //"// <-- This extra comment markers and quote is to stop intellij from messing up the code formatting. https://github.com/amzn/ion-intellij-plugin/issues/40
+    "\\ ",
   ],
   should_reject_as_invalid: [
     "a",
     ".",
-  ]
-}
-
-type::{
-  name: regex_character_class_negated,
-  regex: "[^bcd]",
-}
-$test::{
-  type: regex_character_class_negated,
-  should_accept_as_valid: [
-    "a",
-    "e",
-  ],
-  should_reject_as_invalid: [
-    "b",
-    "c",
-    "d",
   ]
 }
 
@@ -251,19 +713,22 @@ $test::{
 }
 
 type::{
-  name: regex_character_class,
-  regex: "[bcd]",
+  name: regex_character_range,
+  regex: "[b-g]",
 }
 $test::{
-  type: regex_character_class,
+  type: regex_character_range,
   should_accept_as_valid: [
     "b",
     "c",
     "d",
+    "e",
+    "f",
+    "g",
   ],
   should_reject_as_invalid: [
     "a",
-    "e",
+    "i",
   ]
 }
 
@@ -288,281 +753,6 @@ $test::{
 }
 
 type::{
-  name: regex_character_range,
-  regex: "[b-g]",
-}
-$test::{
-  type: regex_character_range,
-  should_accept_as_valid: [
-    "b",
-    "c",
-    "d",
-    "e",
-    "f",
-    "g",
-  ],
-  should_reject_as_invalid: [
-    "a",
-    "i",
-  ]
-}
-
-type::{
-  name: regex_complex_nested_quantified_alternation,
-  regex: "^(ab|(cd){2,3}|ef){2}$",
-}
-$test::{
-  type: regex_complex_nested_quantified_alternation,
-  should_accept_as_valid: [
-    abab,
-    abcdcd,
-    abcdcdcd,
-    abef,
-    cdcdab,
-    cdcdcdab,
-    cdcdcdcd,
-    cdcdcdcdcd,
-    cdcdcdcdcdcd,
-    cdcdcdef,
-    cdcdef,
-    efab,
-    efcdcd,
-    efcdcdcd,
-    efef,
-  ],
-  should_reject_as_invalid: [
-    "",
-    ab,
-    abcdcdcdcd,
-    cd,
-    cdcd,
-    cdcdcd,
-    cdcdcdcdcdcdcd,
-    cdcdcdcdef,
-    ef,
-  ]
-}
-
-type::{
-  name: regex_escape_characters,
-  // There is an space at the end of this regex because the Ion plugin doesn't handle escaped backsalshes at the end
-  // of a string correctly. See https://github.com/amzn/ion-intellij-plugin/issues/40.
-  regex: "\\.\\^\\$\\|\\?\\*\\+\\[\\]\\(\\)\\{\\}\\\\ ",
-}
-$test::{
-  type: regex_escape_characters,
-  should_accept_as_valid: [
-    '.^$|?*+[](){}\\ ',
-    ".^$|?*+[](){}\\ ",
-  ],
-  should_reject_as_invalid: [
-    null,
-    null.null,
-    null.string,
-    null.symbol,
-    null.bool,
-    'hello world',
-    "hello world",
-  ]
-}
-
-type::{
-  name: regex_escape_double_quote,
-  regex: "\"free\"",
-}
-$test::{
-  type: regex_escape_double_quote,
-  should_accept_as_valid: [
-    '"free"',
-    "\"free\"",
-    'Totally "free" food!',
-    "Totally \"free\" food!",
-  ],
-  should_reject_as_invalid: [
-    null,
-    null.null,
-    null.string,
-    null.symbol,
-    null.bool,
-    '',
-    "",
-    'free',
-    "free",
-  ]
-}
-
-type::{
-  name: regex_escape_forwardslash,
-  regex: "a/b",
-}
-$test::{
-  type: regex_escape_forwardslash,
-  should_accept_as_valid: [
-    'a/b',
-    "a/b",
-  ],
-  should_reject_as_invalid: [
-    null,
-    null.null,
-    null.string,
-    null.symbol,
-    null.bool,
-    '',
-    "",
-    ab,
-    "ab",
-  ]
-}
-
-type::{
-  name: regex_escape_single_quote,
-  regex: "it's",
-}
-$test::{
-  type: regex_escape_single_quote,
-  should_accept_as_valid: [
-    'it\'s',
-    "it's",
-    'I can\'t believe it\'s not butter!',
-    "I can't believe it's not butter!",
-  ],
-  should_reject_as_invalid: [
-    null,
-    null.null,
-    null.string,
-    null.symbol,
-    null.bool,
-    '',
-    "",
-    its,
-    "its",
-  ]
-}
-
-type::{
-  name: regex_escape_tab,
-  regex: "hello\tworld",
-}
-$test::{
-  type: regex_escape_tab,
-  should_accept_as_valid: [
-    'hello\tworld',
-    'hello	world',
-    "hello\tworld",
-    "hello	world",
-  ],
-  should_reject_as_invalid: [
-    null,
-    null.null,
-    null.string,
-    null.symbol,
-    null.bool,
-    'hello world',
-    "hello world",
-  ]
-}
-
-type::{
-  name: regex_unescaped_tab,
-  // There is an unescaped tab character in this regex
-  regex: "hello	world",
-}
-$test::{
-  type: regex_unescaped_tab,
-  should_accept_as_valid: [
-    'hello\tworld',
-    'hello	world',
-    "hello\tworld",
-    "hello	world",
-  ],
-  should_reject_as_invalid: [
-    null,
-    null.null,
-    null.string,
-    null.symbol,
-    null.bool,
-    'hello world',
-    "hello world",
-  ]
-}
-
-type::{
-  name: regex_grouping,
-  regex: "123(ab|cd|ef)456",
-}
-$test::{
-  type: regex_grouping,
-  should_accept_as_valid: [
-    "123ab456",
-    "123cd456",
-    "123ef456",
-  ],
-  should_reject_as_invalid: [
-    "123a456",
-    "123ac456",
-    "123ace456",
-    "123bdf456",
-  ]
-}
-
-type::{
-  name: regex_ion_escape_characters,
-  regex: "\0\a\b\t\n\f\r\v",
-}
-$test::{
-  type: regex_ion_escape_characters,
-  should_accept_as_valid: [
-    '\0\a\b\t\n\f\r\v',
-    "\0\a\b\t\n\f\r\v",
-  ],
-  should_reject_as_invalid: [
-    null,
-    null.null,
-    null.string,
-    null.symbol,
-    null.bool,
-    'hello world',
-    "hello world",
-  ]
-}
-
-type::{
-  name: regex_multiline,
-  regex: m::"^hello world$",
-}
-$test::{
-  type: regex_multiline,
-  should_accept_as_valid: [
-    'hello world',
-    'hello world\n\n\n',
-    '\n\n\nhello world',
-    '\n\n\nhello world\n\n\n',
-    '\r\r\rhello world\r\r\r',
-
-    "hello world",
-    "hello world\n\n\n",
-    "\n\n\nhello world",
-    "\n\n\nhello world\n\n\n",
-    "\r\r\rhello world\r\r\r",
-  ],
-  should_reject_as_invalid: [
-    null,
-    null.null,
-    null.string,
-    null.symbol,
-    null.bool,
-    " hello world",
-    "hello world ",
-    "\n hello world",
-    "hello world \n",
-    "hello\n world",
-    "hello \nworld",
-    "hello\r world",
-    "hello \rworld",
-  ]
-}
-
-type::{
   name: regex_predefined_character_class_digit,
   regex: "\\d",
 }
@@ -583,6 +773,8 @@ $test::{
   should_reject_as_invalid: [
     "/",
     ":",
+    "a",
+    ".",
   ]
 }
 
@@ -595,6 +787,8 @@ $test::{
   should_accept_as_valid: [
     "/",
     ":",
+    "a",
+    ".",
   ],
   should_reject_as_invalid: [
     "0",
@@ -645,6 +839,7 @@ $test::{
     "[",
     "`",
     "{",
+    " ",
   ],
   should_reject_as_invalid: [
     "a",
@@ -653,6 +848,7 @@ $test::{
     "Z",
     "0",
     "9",
+    "_",
   ]
 }
 
@@ -701,44 +897,73 @@ $test::{
     "`",
     "{",
     "-",
+    " ",
   ]
 }
 
 type::{
   name: regex_character_class_compound,
-  regex: "[ac-eh-jmnt-vz]",
+  regex: "[abc0-3def4-6ghi]",
 }
 $test::{
   type: regex_character_class_compound,
   should_accept_as_valid: [
-    "a",
-    "c",
-    "d",
-    "e",
-    "h",
-    "i",
-    "j",
-    "m",
-    "n",
-    "t",
-    "u",
-    "v",
-    "z",
+    a,
+    b,
+    c,
+    d,
+    e,
+    f,
+    g,
+    h,
+    i,
+    "0",
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
   ],
   should_reject_as_invalid: [
-    "b",
+    j,
+    k,
+    l,
+    "7",
+    "8",
+    "9",
+  ]
+}
+
+type::{
+  name: regex_character_class_compound_negated,
+  regex: "[^a-c123w-z]",
+}
+$test::{
+  type: regex_character_class_compound_negated,
+  should_accept_as_valid: [
+    "d",
+    "e",
     "f",
-    "g",
-    "k",
-    "l",
-    "o",
-    "p",
-    "q",
-    "r",
-    "s",
-    "w",
-    "x",
-    "y",
+    p,
+    q,
+    r,
+    s,
+    "0",
+    "4",
+    "5",
+  ],
+  should_reject_as_invalid: [
+    "a",
+    "b",
+    "c",
+    w,
+    x,
+    y,
+    z,
+    "1",
+    "2",
+    "3",
   ]
 }
 
@@ -749,12 +974,12 @@ type::{
 $test::{
   type: regex_character_class_unioned_with_d_metachar_class,
   should_accept_as_valid: [
-    "a",
-    "b",
-    "c",
-    "d",
-    "e",
-    "f",
+    a,
+    b,
+    c,
+    d,
+    e,
+    f,
     "0",
     "1",
     "2",
@@ -767,22 +992,9 @@ $test::{
     "9",
   ],
   should_reject_as_invalid: [
-    "g",
-    "h",
-    "i",
-    "j",
-    "k",
-    "l",
-    "m",
-    "n",
-    "o",
-    "p",
-    "q",
-    "r",
-    "s",
-    "t",
-    "u",
-    "v",
+    g,
+    h,
+    i,
     "w",
     "x",
     "y",
@@ -881,12 +1093,6 @@ $test::{
     "1",
     "2",
     "3",
-    "4",
-    "5",
-    "6",
-    "7",
-    "8",
-    "9",
     "d",
     "e",
     "f",
@@ -924,6 +1130,7 @@ $test::{
     "@",
     "🤨",
     "\b",
+    "\0",
   ]
 }
 
@@ -945,146 +1152,12 @@ $test::{
     "🤨",
     "\b",
     " ",
+    "\0",
   ],
   should_reject_as_invalid: [
     "\f",
     "\n",
     "\r",
     "\t",
-  ]
-}
-
-type::{
-  name: regex_quantifier_at_least_n,
-  regex: "ab{3,}c",
-}
-$test::{
-  type: regex_quantifier_at_least_n,
-  should_accept_as_valid: [
-    "abbbc",
-    "abbbbc",
-    "abbbbbc",
-  ],
-  should_reject_as_invalid: [
-    "ac",
-    "abc",
-    "abbc",
-  ]
-}
-
-type::{
-  name: regex_quantifier_exactly_n,
-  regex: "ab{3}c",
-}
-$test::{
-  type: regex_quantifier_exactly_n,
-  should_accept_as_valid: [
-    "abbbc",
-  ],
-  should_reject_as_invalid: [
-    "abbc",
-    "abbbbc",
-  ]
-}
-
-type::{
-  name: regex_quantifier_one_to_many,
-  regex: "ab+c",
-}
-$test::{
-  type: regex_quantifier_one_to_many,
-  should_accept_as_valid: [
-    "abc",
-    "abbc",
-    "abbbc",
-  ],
-  should_reject_as_invalid: [
-    "ac",
-  ]
-}
-
-type::{
-  name: regex_quantifier_range,
-  regex: "ab{2,4}c",
-}
-$test::{
-  type: regex_quantifier_range,
-  should_accept_as_valid: [
-    "abbc",
-    "abbbc",
-    "abbbc",
-  ],
-  should_reject_as_invalid: [
-    "abc",
-    "abbbbbc",
-  ]
-}
-
-type::{
-  name: regex_quantifier_zero_or_one,
-  regex: "ab?c",
-}
-$test::{
-  type: regex_quantifier_zero_or_one,
-  should_accept_as_valid: [
-    "ac",
-    "abc",
-  ],
-  should_reject_as_invalid: [
-    "abbc",
-  ]
-}
-
-type::{
-  name: regex_quantifier_zero_to_many,
-  regex: "ab*c",
-}
-$test::{
-  type: regex_quantifier_zero_to_many,
-  should_accept_as_valid: [
-    "ac",
-    "abc",
-    "abbc",
-    "abbbc",
-  ],
-  should_reject_as_invalid: [
-    "",
-    "ab",
-    "bc",
-  ]
-}
-
-type::{
-  name: regex_special_characters,
-  regex: "\0\a\b\t\n\v\f\r",
-}
-$test::{
-  type: regex_special_characters,
-  should_accept_as_valid: [
-    '\0\a\b\t\n\v\f\r',
-    "\0\a\b\t\n\v\f\r",
-  ],
-  should_reject_as_invalid: [
-    a,
-    "A",
-  ]
-}
-
-type::{
-  name: regex_unicode_emoji,
-  regex: "^[😀\U0001f642😊]{3,6}$",
-}
-$test::{
-  type: regex_unicode_emoji,
-  should_accept_as_valid: [
-    "😊😀🙂",
-    "🙂🙂🙂🙂",
-    "😊😊😊😊😊",
-    "😊😀🙂😊😀🙂",
-    "\U0001f600\U0001f600\U0001f600",
-  ],
-  should_reject_as_invalid: [
-    "😊😀",
-    "😊😀🙂😊😀🙂😊",
   ]
 }

--- a/ion_schema_2_0/constraints/regex.isl
+++ b/ion_schema_2_0/constraints/regex.isl
@@ -1005,19 +1005,18 @@ $test::{
 
 type::{
   name: regex_quantifier_range,
-  regex: "ab{3,6}c",
+  regex: "ab{2,4}c",
 }
 $test::{
   type: regex_quantifier_range,
   should_accept_as_valid: [
+    "abbc",
     "abbbc",
-    "abbbbc",
-    "abbbbbc",
-    "abbbbbbc",
+    "abbbc",
   ],
   should_reject_as_invalid: [
-    "abbc",
-    "abbbbbbbc",
+    "abc",
+    "abbbbbc",
   ]
 }
 


### PR DESCRIPTION
**Issue #, if available:**

#32 

**Description of changes:**

Adds Ion Schema 2.0 test cases for regex constraint.

I can split this into a few more files if you think that would help with readability and maintainability.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
