### PR TITLE
Adds flag to mark some tests as out-of-scope for ion-schema-schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ A test case that checks that a schema document is correctly recognized as invali
 $test::{
   // A useful description of the test to aid with debugging, understanding the spec, etc.
   description: "A schema with two version markers is invalid",
-  
+
+  // Indicates that ISL for ISL cannot detect that this schema as invalid. 
+  // This is an optional field that indicates whether an ISL for ISL test runners should run this test case.
+  // If the field is not present, it is assumed to be "true".
+  isl_for_isl_can_validate: false,
+
   // The actual schema, embedded in a s-expression. Test runners must convert this s-expression to a document.
   invalid_schema:(
     $ion_schema_2_0
@@ -87,9 +92,14 @@ E.g. "Regex must be a string [1]"
 $test::{
   // A useful description of the test to aid with debugging, understanding the spec, etc.
   description: "Regex must be a string",
-  
+
+  // Indicates that ISL for ISL cannot detect that this type as invalid. 
+  // This is an optional field that indicates whether an ISL for ISL test runners should run this test case.
+  // If the field is not present, it is assumed to be "true".
+  isl_for_isl_can_validate: false,
+
   // A list of types that are invalid. They should be detected as invalid by both the Ion Schema implementation and
-  // by the types defined in ion-schema-schemas.
+  // by the types defined in ion-schema-schemas, except as noted above.
   invalid_types: [
     { regex: 1 },
     { regex: false },
@@ -129,13 +139,15 @@ type::{
     {
       fields: closed::{
         description: { type: string, occurs: required },
-        invalid_schema: { type: sexp, occurs: required }
+        invalid_schema: { type: sexp, occurs: required },
+        isl_for_isl_can_validate: bool,
       }
     },
     {
       fields: closed::{
         description: { type: string, occurs: required },
-        invalid_types: { type: list, occurs: required }
+        invalid_types: { type: list, occurs: required },
+        isl_for_isl_can_validate: bool,
       }
     },
   ]

--- a/ion_schema_1_0/schema/import/invalid_duplicate_import.isl
+++ b/ion_schema_1_0/schema/import/invalid_duplicate_import.isl
@@ -1,6 +1,7 @@
 $ion_schema_1_0
 $test::{
   description: "importing two different schemas with conflicting type names should result in an error",
+  isl_for_isl_can_validate: false,
   invalid_schema: (
 
     $ion_schema_1_0

--- a/ion_schema_1_0/schema/import/invalid_duplicate_import_type.isl
+++ b/ion_schema_1_0/schema/import/invalid_duplicate_import_type.isl
@@ -1,6 +1,7 @@
 $ion_schema_1_0
 $test::{
   description: "importing two different types with the same name should result in an error",
+  isl_for_isl_can_validate: false,
   invalid_schema: (
 
     $ion_schema_1_0

--- a/ion_schema_1_0/schema/import/invalid_duplicate_type.isl
+++ b/ion_schema_1_0/schema/import/invalid_duplicate_type.isl
@@ -1,6 +1,7 @@
 $ion_schema_1_0
 $test::{
   description: "importing a type with the same name as a type in the schema should result in an error",
+  isl_for_isl_can_validate: false,
   invalid_schema: (
 
     $ion_schema_1_0

--- a/ion_schema_1_0/schema/import/invalid_transitive_import_of_schema.isl
+++ b/ion_schema_1_0/schema/import/invalid_transitive_import_of_schema.isl
@@ -1,6 +1,7 @@
 $ion_schema_1_0
 $test::{
   description: "schema imports must not be resolved transitively through another schema",
+  isl_for_isl_can_validate: false,
   invalid_schema: (
 
     // types 'a', 'b', 'c', 'd', and 'e' should not be recognized in this schema:

--- a/ion_schema_1_0/schema/import/invalid_transitive_import_of_type.isl
+++ b/ion_schema_1_0/schema/import/invalid_transitive_import_of_type.isl
@@ -1,6 +1,7 @@
 $ion_schema_1_0
 $test::{
   description: "type imports must not be resolved transitively through another schema",
+  isl_for_isl_can_validate: false,
   invalid_schema: (
 
     // type 'positive_int' should not be recognized in this schema:

--- a/ion_schema_1_0/schema/import/invalid_transitive_import_of_type_by_alias.isl
+++ b/ion_schema_1_0/schema/import/invalid_transitive_import_of_type_by_alias.isl
@@ -1,6 +1,7 @@
 $ion_schema_1_0
 $test::{
-  description: "type imports must not be resolved transitively through another schema",
+  description: "aliased type imports must not be importable by another schema",
+  isl_for_isl_can_validate: false,
   invalid_schema: (
 
     // type 'positive_int_1' should not be recognized in this schema:

--- a/ion_schema_1_0/schema/invalid_missing_schema_footer.isl
+++ b/ion_schema_1_0/schema/invalid_missing_schema_footer.isl
@@ -1,6 +1,7 @@
 $ion_schema_1_0
 $test::{
   description: "missing schema_footer",
+  isl_for_isl_can_validate: false,
   invalid_schema: (
 
     schema_header::{}

--- a/ion_schema_1_0/schema/invalid_missing_schema_header.isl
+++ b/ion_schema_1_0/schema/invalid_missing_schema_header.isl
@@ -1,6 +1,7 @@
 $ion_schema_1_0
 $test::{
   description: "missing schema_header",
+  isl_for_isl_can_validate: false,
   invalid_schema: (
 
     schema_footer::{}

--- a/ion_schema_1_0/schema/invalid_reuse_of_type_name.isl
+++ b/ion_schema_1_0/schema/invalid_reuse_of_type_name.isl
@@ -1,6 +1,7 @@
 $ion_schema_1_0
 $test::{
   description: "two types in a schema cannot have the same name",
+  isl_for_isl_can_validate: false,
   invalid_schema: (
 
     $ion_schema_1_0

--- a/ion_schema_1_0/schema/invalid_unknown_type.isl
+++ b/ion_schema_1_0/schema/invalid_unknown_type.isl
@@ -1,6 +1,7 @@
 $ion_schema_1_0
 $test::{
   description: "type reference that refers to a non-existent type",
+  isl_for_isl_can_validate: false,
   invalid_schema: (
 
     $ion_schema_1_0

--- a/ion_schema_2_0/constraints/all_of.isl
+++ b/ion_schema_2_0/constraints/all_of.isl
@@ -132,9 +132,16 @@ $test::{
     { all_of: "$int" },
     { all_of: { container_length: 5 } },
     { all_of: (int float) },
-    { all_of: [int, float, not_a_real_type] },
     { all_of: [int, float, ()] },
     { all_of: range::[1, 5] },
+  ]
+}
+
+$test::{
+  description: "all_of type references should exist",
+  isl_for_isl_can_validate: false,
+  invalid_types: [
+    { all_of: [int, float, not_a_real_type] },
   ]
 }
 

--- a/ion_schema_2_0/constraints/annotations-standard.isl
+++ b/ion_schema_2_0/constraints/annotations-standard.isl
@@ -52,29 +52,29 @@ $test::{
 }
 
 $test::{
-  description: "annotations argument must not be a sexp",
+  description: "annotations argument must be a type reference",
   invalid_types: [
+    { annotations: null },
     { annotations: (foo bar) },
-  ]
-}
-$test::{
-  description: "annotations argument must not be a string",
-  invalid_types: [
     { annotations: "foo" },
   ]
 }
+
 $test::{
   description: "annotations argument type must exist",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { annotations: some_non_existent_type },
   ]
 }
+
 $test::{
   description: "annotations argument must not be a variably occurring type reference",
   invalid_types: [
     { annotations: { occurs: optional } },
   ]
 }
+
 $test::{
   description: "annotations argument must not define a type name",
   invalid_types: [

--- a/ion_schema_2_0/constraints/any_of.isl
+++ b/ion_schema_2_0/constraints/any_of.isl
@@ -144,9 +144,16 @@ $test::{
     { any_of: "$int" },
     { any_of: { container_length: 5 } },
     { any_of: (int float) },
-    { any_of: [int, float, not_a_real_type] },
     { any_of: [int, float, ()] },
     { any_of: range::[1, 5] },
+  ]
+}
+
+$test::{
+  description: "any_of type references should exist",
+  isl_for_isl_can_validate: false,
+  invalid_types: [
+    { any_of: [int, float, not_a_real_type] },
   ]
 }
 

--- a/ion_schema_2_0/constraints/byte_length.isl
+++ b/ion_schema_2_0/constraints/byte_length.isl
@@ -74,16 +74,24 @@ $test::{
     { byte_length: range::(1 2) },
     { byte_length: range::[min, max] },
     { byte_length: range::null.list },
-    { byte_length: range::[2, 1] },
     { byte_length: range::[1] },
     { byte_length: range::[1, 2, 3] },
     { byte_length: range::[1d0, 2] },
     { byte_length: range::[1, 2d0] },
     { byte_length: range::[1e0, 2] },
     { byte_length: range::[1, 2e0] },
+  ]
+}
+
+$test::{
+  description: "byte_length range must not be non-empty",
+  isl_for_isl_can_validate: false,
+  invalid_types:[
+    { byte_length: range::[2, 1] },
     { byte_length: range::[exclusive::1, exclusive::2] },
   ]
 }
+
 $test::{
   description: "byte_length must be an integer or a range",
   invalid_types:[

--- a/ion_schema_2_0/constraints/codepoint_length.isl
+++ b/ion_schema_2_0/constraints/codepoint_length.isl
@@ -62,16 +62,24 @@ $test::{
     { codepoint_length: range::(1 2) },
     { codepoint_length: range::[min, max] },
     { codepoint_length: range::null.list },
-    { codepoint_length: range::[2, 1] },
     { codepoint_length: range::[1] },
     { codepoint_length: range::[1, 2, 3] },
     { codepoint_length: range::[1d0, 2] },
     { codepoint_length: range::[1, 2d0] },
     { codepoint_length: range::[1e0, 2] },
     { codepoint_length: range::[1, 2e0] },
+  ]
+}
+
+$test::{
+  description: "codepoint_length range must not be non-empty",
+  isl_for_isl_can_validate: false,
+  invalid_types:[
+    { codepoint_length: range::[2, 1] },
     { codepoint_length: range::[exclusive::1, exclusive::2] },
   ]
 }
+
 $test::{
   description: "codepoint_length must be an integer or a range",
   invalid_types:[

--- a/ion_schema_2_0/constraints/container_length.isl
+++ b/ion_schema_2_0/constraints/container_length.isl
@@ -85,16 +85,24 @@ $test::{
     { container_length: range::(1 2) },
     { container_length: range::[min, max] },
     { container_length: range::null.list },
-    { container_length: range::[2, 1] },
     { container_length: range::[1] },
     { container_length: range::[1, 2, 3] },
     { container_length: range::[1d0, 2] },
     { container_length: range::[1, 2d0] },
     { container_length: range::[1e0, 2] },
     { container_length: range::[1, 2e0] },
+  ]
+}
+
+$test::{
+  description: "container_length range must not be non-empty",
+  isl_for_isl_can_validate: false,
+  invalid_types:[
+    { container_length: range::[2, 1] },
     { container_length: range::[exclusive::1, exclusive::2] },
   ]
 }
+
 $test::{
   description: "container_length must be an integer or a range",
   invalid_types:[
@@ -110,5 +118,5 @@ $test::{
     { container_length: 3e0 },
     { container_length: {{ "1" }} },
     { container_length: {{ aGVsbG8= }} },
-    ]
+  ]
 }

--- a/ion_schema_2_0/constraints/exponent.isl
+++ b/ion_schema_2_0/constraints/exponent.isl
@@ -66,13 +66,20 @@ $test::{
     { exponent: range::(1 2) },
     { exponent: range::[min, max] },
     { exponent: range::null.list },
-    { exponent: range::[2, 1] },
     { exponent: range::[1] },
     { exponent: range::[1, 2, 3] },
     { exponent: range::[1d0, 2] },
     { exponent: range::[1, 2d0] },
     { exponent: range::[1e0, 2] },
     { exponent: range::[1, 2e0] },
+  ]
+}
+
+$test::{
+  description: "exponent range must not be non-empty",
+  isl_for_isl_can_validate: false,
+  invalid_types:[
+    { exponent: range::[2, 1] },
     { exponent: range::[exclusive::1, exclusive::2] },
   ]
 }

--- a/ion_schema_2_0/constraints/one_of.isl
+++ b/ion_schema_2_0/constraints/one_of.isl
@@ -152,9 +152,16 @@ $test::{
     { one_of: "$int" },
     { one_of: { container_length: 5 } },
     { one_of: (int float) },
-    { one_of: [int, float, not_a_real_type] },
     { one_of: [int, float, ()] },
     { one_of: range::[1, 5] },
+  ]
+}
+
+$test::{
+  description: "one_of type references should exist",
+  isl_for_isl_can_validate: false,
+  invalid_types: [
+    { one_of: [int, float, not_a_real_type] },
   ]
 }
 

--- a/ion_schema_2_0/constraints/precision.isl
+++ b/ion_schema_2_0/constraints/precision.isl
@@ -75,16 +75,24 @@ $test::{
     { precision: range::(1 2) },
     { precision: range::[min, max] },
     { precision: range::null.list },
-    { precision: range::[2, 1] },
     { precision: range::[1] },
     { precision: range::[1, 2, 3] },
     { precision: range::[1d0, 2] },
     { precision: range::[1, 2d0] },
     { precision: range::[1e0, 2] },
     { precision: range::[1, 2e0] },
+  ]
+}
+
+$test::{
+  description: "precision range must not be non-empty",
+  isl_for_isl_can_validate: false,
+  invalid_types:[
+    { precision: range::[2, 1] },
     { precision: range::[exclusive::1, exclusive::2] },
   ]
 }
+
 $test::{
   description: "precision must be an integer or a range",
   invalid_types:[

--- a/ion_schema_2_0/constraints/regex-invalid.isl
+++ b/ion_schema_2_0/constraints/regex-invalid.isl
@@ -41,6 +41,7 @@ $test::{
 
 $test::{
   description: "Backreferences are not allowed",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "\\1" },
   ]
@@ -48,6 +49,7 @@ $test::{
 
 $test::{
   description: "POSIX character classes are not allowed",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "\\p{Lower}" },
   ]
@@ -55,6 +57,7 @@ $test::{
 
 $test::{
   description: "Invalid escaped character",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "\\A" },
     { regex: "\\b" },
@@ -76,6 +79,7 @@ $test::{
 
 $test::{
   description: "invalid character classes/ranges",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "[a-d[m-p]]" },
     { regex: "[a-z&&[def]]" },
@@ -85,6 +89,7 @@ $test::{
 
 $test::{
   description: "reluctant quantifiers are not allowed",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "abc??" },
     { regex: "abc*?" },
@@ -97,6 +102,7 @@ $test::{
 
 $test::{
   description: "possessive quantifiers are not allowed",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "abc?+" },
     { regex: "abc*+" },
@@ -109,6 +115,7 @@ $test::{
 
 $test::{
   description: "quantifier must have an explicit lower bound",
+  isl_for_isl_can_validate: false,
   invalid_types:[
     { regex: "a{,2}", }
   ],
@@ -116,6 +123,7 @@ $test::{
 
 $test::{
   description: '''special constructs with prefix "(?" are not allowed''',
+  isl_for_isl_can_validate: false,
   invalid_types:[
     { regex: "(?" }
   ],

--- a/ion_schema_2_0/constraints/timestamp_precision.isl
+++ b/ion_schema_2_0/constraints/timestamp_precision.isl
@@ -108,9 +108,18 @@ $test::{
     { timestamp_precision: range::null.list },
     { timestamp_precision: range::[minute, -6] },
     { timestamp_precision: range::[year, month, day] },
-    { timestamp_precision: range::[exclusive::minute, exclusive::second] },
   ]
 }
+
+$test::{
+  description: "timestamp_precision range must not be non-empty",
+  isl_for_isl_can_validate: false,
+  invalid_types:[
+    { timestamp_precision: range::[exclusive::minute, exclusive::second] },
+    { timestamp_precision: range::[second, exclusive::second] },
+  ]
+}
+
 $test::{
   description: "timestamp_precision range lower bound must not be greater than upper bound",
   invalid_types: [

--- a/ion_schema_2_0/constraints/utf8_byte_length.isl
+++ b/ion_schema_2_0/constraints/utf8_byte_length.isl
@@ -64,16 +64,24 @@ $test::{
     { utf8_byte_length: range::(1 2) },
     { utf8_byte_length: range::[min, max] },
     { utf8_byte_length: range::null.list },
-    { utf8_byte_length: range::[2, 1] },
     { utf8_byte_length: range::[1] },
     { utf8_byte_length: range::[1, 2, 3] },
     { utf8_byte_length: range::[1d0, 2] },
     { utf8_byte_length: range::[1, 2d0] },
     { utf8_byte_length: range::[1e0, 2] },
     { utf8_byte_length: range::[1, 2e0] },
+  ]
+}
+
+$test::{
+  description: "utf8_byte_length range must not be non-empty",
+  isl_for_isl_can_validate: false,
+  invalid_types:[
+    { utf8_byte_length: range::[2, 1] },
     { utf8_byte_length: range::[exclusive::1, exclusive::2] },
   ]
 }
+
 $test::{
   description: "utf8_byte_length must be an integer or a range",
   invalid_types:[

--- a/ion_schema_2_0/constraints/valid_values-ranges.isl
+++ b/ion_schema_2_0/constraints/valid_values-ranges.isl
@@ -364,12 +364,19 @@ $test::{
 $test::{
   description: "valid_values ranges must be valid number or timestamp ranges",
   invalid_types: [
-    { valid_values: range::[ 1, 0 ] },
-    { valid_values: range::[ 0.00000000001, 0 ] },
     { valid_values: range::[ min, max ] },
     { valid_values: range::[ 1, exclusive::max ] },
     { valid_values: range::[ exclusive::min, 100 ] },
     { valid_values: range::[ 2000T, 3000.0] },
+  ]
+}
+
+$test::{
+  description: "valid_values ranges must not be non-empty",
+  isl_for_isl_can_validate: false,
+  invalid_types:[
+    { valid_values: range::[ 1, 0 ] },
+    { valid_values: range::[ 0.00000000001, 0 ] },
     { valid_values: range::[ exclusive::1, exclusive::1 ] },
   ]
 }

--- a/ion_schema_tests.isl
+++ b/ion_schema_tests.isl
@@ -16,14 +16,16 @@ type::{
     {
       fields: {
         description: { type: string, occurs: required },
-        invalid_schema: { type: sexp, occurs: required }
+        invalid_schema: { type: sexp, occurs: required },
+        isl_for_isl_can_validate: bool,
       },
       content: closed,
     },
     {
       fields: {
         description: { type: string, occurs: required },
-        invalid_types: { type: list, occurs: required }
+        invalid_types: { type: list, occurs: required },
+        isl_for_isl_can_validate: bool,
       },
       content: closed,
     },


### PR DESCRIPTION
**Issue #, if available:**

#32 

**Description of changes:**

Updates the test spec with a way to mark tests that should be skipped when testing with ISL for ISL, and updates all Ion Schema Tests that need to be skipped.

Rather than having a blocked/skip list in every implementation that runs the ISL for ISL tests, we should just mark the test cases themselves and include a reason why the test case is to be skipped. This approach is better than the existing approach because it is more fine-grained than having a file-based blocked/skip list, and it documents the reason the particular test cases are skipped.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
