### PR TITLE
Adds negative tests for ISL 2.0 top-level schema elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ There are three explicit and two implicit types of test cases.
 
 1. `valid_schema` (implicit) – asserts that a schema document is valid.
     Every test file should be a valid schema, so this is implied for every schema/file that is present in the test suite.
-2. `invalid_schema` – asserts that a schema document is invalid.
+2. `invalid_schemas` – asserts that each schema document in a given list of schema documents is invalid.
 3. `valid_type` – (implicit) asserts that a given type definition is valid.
     Every top-level type in the test suite loaded and implicitly tested for validity. 
 4. `invalid_types` – asserts that each type in a given list of type definitions is invalid.
@@ -58,8 +58,8 @@ $test::{
 }
 ```
 
-#### `invalid_schema` Tests
-A test case that checks that a schema document is correctly recognized as invalid.
+#### `invalid_schemas` Tests
+A test case that checks that the given schema documents are correctly recognized as invalid.
 ```ion
 $test::{
   // A useful description of the test to aid with debugging, understanding the spec, etc.
@@ -70,17 +70,29 @@ $test::{
   // If the field is not present, it is assumed to be "true".
   isl_for_isl_can_validate: false,
 
-  // The actual schema, embedded in a s-expression. Test runners must convert this s-expression to a document.
-  invalid_schema:(
-    $ion_schema_2_0
-    $ion_schema_1_0
-    schema_header::{}
-    type::{
-      name: foo,
-      type: int,
-    }
-    schema_footer::{}
-  )
+  // The actual schemas, embedded in a s-expression. Test runners must convert these s-expressions to a document.
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      $ion_schema_1_0
+      schema_header::{}
+      type::{
+        name: foo,
+        type: int,
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+        type: int,
+      }
+      schema_footer::{}
+    ),
+  ]
 }
 ```
 
@@ -139,7 +151,7 @@ type::{
     {
       fields: closed::{
         description: { type: string, occurs: required },
-        invalid_schema: { type: sexp, occurs: required },
+        invalid_schemas: { type: list, occurs: required, element: sexp },
         isl_for_isl_can_validate: bool,
       }
     },

--- a/ion_schema_1_0/schema/import/import_type_unknown.isl
+++ b/ion_schema_1_0/schema/import/import_type_unknown.isl
@@ -2,7 +2,7 @@ $ion_schema_1_0
 
 $test::{
   description: "attempting to import an unknown type should result in an error",
-  invalid_schema: (
+  invalid_schemas: [ (
     schema_header::{
       imports: [
         { id: "schema/util/positive_int.isl", type: unknown_type }
@@ -10,5 +10,5 @@ $test::{
     }
     schema_footer::{
     }
-  )
+  ) ]
 }

--- a/ion_schema_1_0/schema/import/invalid_duplicate_import.isl
+++ b/ion_schema_1_0/schema/import/invalid_duplicate_import.isl
@@ -2,7 +2,7 @@ $ion_schema_1_0
 $test::{
   description: "importing two different schemas with conflicting type names should result in an error",
   isl_for_isl_can_validate: false,
-  invalid_schema: (
+  invalid_schemas: [ (
 
     $ion_schema_1_0
     schema_header::{
@@ -13,5 +13,5 @@ $test::{
     }
     schema_footer::{}
 
-  )
+  ) ]
 }

--- a/ion_schema_1_0/schema/import/invalid_duplicate_import_type.isl
+++ b/ion_schema_1_0/schema/import/invalid_duplicate_import_type.isl
@@ -2,7 +2,7 @@ $ion_schema_1_0
 $test::{
   description: "importing two different types with the same name should result in an error",
   isl_for_isl_can_validate: false,
-  invalid_schema: (
+  invalid_schemas: [ (
 
     $ion_schema_1_0
     schema_header::{
@@ -13,5 +13,5 @@ $test::{
     }
     schema_footer::{}
 
-  )
+  ) ]
 }

--- a/ion_schema_1_0/schema/import/invalid_duplicate_type.isl
+++ b/ion_schema_1_0/schema/import/invalid_duplicate_type.isl
@@ -2,7 +2,7 @@ $ion_schema_1_0
 $test::{
   description: "importing a type with the same name as a type in the schema should result in an error",
   isl_for_isl_can_validate: false,
-  invalid_schema: (
+  invalid_schemas: [ (
 
     $ion_schema_1_0
     schema_header::{
@@ -15,5 +15,5 @@ $test::{
     }
     schema_footer::{}
 
-  )
+  ) ]
 }

--- a/ion_schema_1_0/schema/import/invalid_transitive_import_of_schema.isl
+++ b/ion_schema_1_0/schema/import/invalid_transitive_import_of_schema.isl
@@ -2,7 +2,7 @@ $ion_schema_1_0
 $test::{
   description: "schema imports must not be resolved transitively through another schema",
   isl_for_isl_can_validate: false,
-  invalid_schema: (
+  invalid_schemas: [ (
 
     // types 'a', 'b', 'c', 'd', and 'e' should not be recognized in this schema:
     $ion_schema_1_0
@@ -17,5 +17,5 @@ $test::{
     }
     schema_footer::{}
 
-  )
+  ) ]
 }

--- a/ion_schema_1_0/schema/import/invalid_transitive_import_of_type.isl
+++ b/ion_schema_1_0/schema/import/invalid_transitive_import_of_type.isl
@@ -2,7 +2,7 @@ $ion_schema_1_0
 $test::{
   description: "type imports must not be resolved transitively through another schema",
   isl_for_isl_can_validate: false,
-  invalid_schema: (
+  invalid_schemas: [ (
 
     // type 'positive_int' should not be recognized in this schema:
     $ion_schema_1_0
@@ -17,5 +17,5 @@ $test::{
     }
     schema_footer::{}
 
-  )
+  ) ]
 }

--- a/ion_schema_1_0/schema/import/invalid_transitive_import_of_type_by_alias.isl
+++ b/ion_schema_1_0/schema/import/invalid_transitive_import_of_type_by_alias.isl
@@ -2,7 +2,7 @@ $ion_schema_1_0
 $test::{
   description: "aliased type imports must not be importable by another schema",
   isl_for_isl_can_validate: false,
-  invalid_schema: (
+  invalid_schemas: [ (
 
     // type 'positive_int_1' should not be recognized in this schema:
     $ion_schema_1_0
@@ -17,6 +17,6 @@ $test::{
     }
     schema_footer::{}
 
-  )
+  ) ]
 }
 

--- a/ion_schema_1_0/schema/invalid_missing_schema_footer.isl
+++ b/ion_schema_1_0/schema/invalid_missing_schema_footer.isl
@@ -2,9 +2,9 @@ $ion_schema_1_0
 $test::{
   description: "missing schema_footer",
   isl_for_isl_can_validate: false,
-  invalid_schema: (
+  invalid_schemas: [ (
 
     schema_header::{}
 
-  )
+  ) ]
 }

--- a/ion_schema_1_0/schema/invalid_missing_schema_header.isl
+++ b/ion_schema_1_0/schema/invalid_missing_schema_header.isl
@@ -2,9 +2,9 @@ $ion_schema_1_0
 $test::{
   description: "missing schema_header",
   isl_for_isl_can_validate: false,
-  invalid_schema: (
+  invalid_schemas: [ (
 
     schema_footer::{}
 
-  )
+  ) ]
 }

--- a/ion_schema_1_0/schema/invalid_reuse_of_type_name.isl
+++ b/ion_schema_1_0/schema/invalid_reuse_of_type_name.isl
@@ -2,7 +2,7 @@ $ion_schema_1_0
 $test::{
   description: "two types in a schema cannot have the same name",
   isl_for_isl_can_validate: false,
-  invalid_schema: (
+  invalid_schemas: [ (
 
     $ion_schema_1_0
     schema_header::{}
@@ -10,5 +10,5 @@ $test::{
     type::{ name: foo, type: int, valid_values: [1, 2, 3] }
     schema_footer::{}
 
-  )
+  ) ]
 }

--- a/ion_schema_1_0/schema/invalid_unknown_type.isl
+++ b/ion_schema_1_0/schema/invalid_unknown_type.isl
@@ -2,7 +2,7 @@ $ion_schema_1_0
 $test::{
   description: "type reference that refers to a non-existent type",
   isl_for_isl_can_validate: false,
-  invalid_schema: (
+  invalid_schemas: [ (
 
     $ion_schema_1_0
     schema_header::{}
@@ -11,5 +11,5 @@ $test::{
     }
     schema_footer::{}
 
-  )
+  ) ]
 }

--- a/ion_schema_1_0/schema/invalid_unnamed_type.isl
+++ b/ion_schema_1_0/schema/invalid_unnamed_type.isl
@@ -1,7 +1,7 @@
 $ion_schema_1_0
 $test::{
   description: "top-level type that doesn't have a name",
-  invalid_schema: (
+  invalid_schemas: [ (
 
     $ion_schema_1_0
     schema_header::{}
@@ -10,12 +10,12 @@ $test::{
     }
     schema_footer::{}
 
-  )
+  ) ]
 }
 
 $test::{
   description: "top-level type named null",
-  invalid_schema: (
+  invalid_schemas: [ (
 
     $ion_schema_1_0
     schema_header::{}
@@ -25,12 +25,12 @@ $test::{
     }
     schema_footer::{}
 
-  )
+  ) ]
 }
 
 $test::{
   description: "top-level type named null.symbol",
-  invalid_schema: (
+  invalid_schemas: [ (
 
     $ion_schema_1_0
     schema_header::{}
@@ -40,5 +40,5 @@ $test::{
     }
     schema_footer::{}
 
-  )
+  ) ]
 }

--- a/ion_schema_2_0/schema/ion_schema_version_markers.isl
+++ b/ion_schema_2_0/schema/ion_schema_version_markers.isl
@@ -1,0 +1,92 @@
+$ion_schema_2_0
+
+$test::{
+  description: "Schema should have only one Ion Schema version marker.",
+  invalid_schemas:[
+    (
+      $ion_schema_2_0
+      $ion_schema_1_0
+      header::{}
+      type::{
+        name: foo
+      }
+      footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      $ion_schema_2_0
+      header::{}
+      type::{
+        name: foo
+      }
+      footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      header::{}
+      type::{
+        name: foo
+      }
+      footer::{}
+      $ion_schema_2_0
+    ),
+    (
+      $ion_schema_2_0
+      type::{
+        name: foo
+      }
+      $ion_schema_2_0
+    ),
+  ]
+}
+
+$test::{
+  description: "Ion Schema version marker must be a real version.",
+  // Note—'$ion_schema_2_1' is intentionally not in this list because any implementation that supports
+  // the hypothetical Ion Schema 2.1 must also support Ion Schema 2.0 (and pass these tests)
+  invalid_schemas:[
+    (
+      $ion_schema_0_1
+      type::{
+        name: foo
+      }
+      footer::{}
+    ),
+    (
+      $ion_schema_2_x
+      type::{
+        name: foo
+      }
+      footer::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "Ion Schema version marker must come before header if header is present.",
+  invalid_schemas:[
+    (
+      header::{}
+      $ion_schema_2_0
+      type::{
+        name: foo
+      }
+      footer::{}
+    )
+  ]
+}
+
+$test::{
+  description: "Ion Schema version marker must come before any types.",
+  invalid_schemas:[
+    (
+      type::{
+        name: foo,
+      }
+      $ion_schema_2_0
+      type::{
+        name: bar,
+      }
+    )
+  ]
+}

--- a/ion_schema_2_0/schema/schema_footer.isl
+++ b/ion_schema_2_0/schema/schema_footer.isl
@@ -1,0 +1,162 @@
+$ion_schema_2_0
+
+$test::{
+  description: "Schema should have at most one schema footer.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo
+      }
+      schema_footer::{}
+      schema_footer::{}
+    )
+  ]
+}
+
+$test::{
+  description: "Schema footer must be present if header is present.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo
+      }
+    ),
+  ]
+}
+
+$test::{
+  description: "Schema footer must not be present if header is not present.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      type::{
+        name: foo
+      }
+      schema_footer::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "Schema footer must not be present if header is not present.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_footer::{}
+      schema_header::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "Schema footer must come after any type definitions.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+      type::{
+        name: bar,
+      }
+    ),
+  ]
+}
+
+$test::{
+  description: "Schema footer must not have any additional annotations.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::type::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::schema_header::{}
+    ),
+    (
+    $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::$foo::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      $foo::schema_footer::{}
+    ),
+  ],
+}
+
+$test::{
+  description: "Schema footer must be a non-null struct.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::null.struct
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::[]
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::()
+    ),
+    (
+    $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::true
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::'foo'
+    ),
+  ],
+}

--- a/ion_schema_2_0/schema/schema_footer.isl
+++ b/ion_schema_2_0/schema/schema_footer.isl
@@ -42,7 +42,7 @@ $test::{
 }
 
 $test::{
-  description: "Schema footer must not be present if header is not present.",
+  description: "Schema footer must come after schema header.",
   invalid_schemas: [
     (
       $ion_schema_2_0

--- a/ion_schema_2_0/schema/schema_header.isl
+++ b/ion_schema_2_0/schema/schema_header.isl
@@ -1,0 +1,134 @@
+$ion_schema_2_0
+
+$test::{
+  description: "Schema should have at most one schema header.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_header::{}
+      type::{
+        name: foo
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: foo
+      }
+      schema_footer::{}
+      schema_header::{}
+    )
+  ]
+}
+
+$test::{
+  description: "Schema header must come before any type definitions.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      type::{
+        name: foo,
+      }
+      schema_header::{}
+      type::{
+        name: bar,
+      }
+      schema_footer::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "Schema header must not have any additional annotations.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::type::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::schema_footer::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::$foo::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      $foo::schema_header::{}
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+    ),
+  ],
+}
+
+$test::{
+  description: "Schema header must be a non-null struct.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::null.struct
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::[]
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::()
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::true
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::'foo'
+      type::{
+        name: foo,
+      }
+      schema_footer::{}
+    ),
+  ],
+}

--- a/ion_schema_2_0/schema/type.isl
+++ b/ion_schema_2_0/schema/type.isl
@@ -1,0 +1,98 @@
+$ion_schema_2_0
+
+$test::{
+  description: "Top level type definitions must not have any additional annotations.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      type::$foo::{ name: foo }
+    ),
+    (
+      $ion_schema_2_0
+      type::type::{ name: foo }
+    ),
+    (
+      $ion_schema_2_0
+      $foo::type::{ name: foo }
+    ),
+  ],
+}
+
+$test::{
+  description: "Top level type definitions must be a non-null struct.",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      type::null.struct
+    ),
+    (
+      $ion_schema_2_0
+      type::[]
+    ),
+    (
+      $ion_schema_2_0
+      type::()
+    ),
+    (
+      $ion_schema_2_0
+      type::$int
+    ),
+  ],
+}
+
+$test::{
+  description: "Top level type definitions must have one name field",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      type::{
+        // No Name
+      }
+    ),
+    (
+      $ion_schema_2_0
+      type::{
+        name: foo,
+        name: bar,
+      }
+    ),
+    (
+      $ion_schema_2_0
+      type::{
+        // Still invalid even if the field value is the same
+        name: foo,
+        name: foo,
+      }
+    ),
+    (
+      $ion_schema_2_0
+      type::{
+        // Still invalid even if one of the values isn't a symbol
+        name: foo,
+        name: false,
+      }
+    ),
+  ],
+}
+
+$test::{
+  description: "Type name field must be a non-null, unannotated symbol",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      type::{ name: "foo" }
+    ),
+    (
+    $ion_schema_2_0
+      type::{ name: null }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: null.symbol }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: foo::bar }
+    ),
+  ],
+}

--- a/ion_schema_tests.isl
+++ b/ion_schema_tests.isl
@@ -16,7 +16,7 @@ type::{
     {
       fields: {
         description: { type: string, occurs: required },
-        invalid_schema: { type: sexp, occurs: required },
+        invalid_schemas: { type: list, occurs: required, element: sexp },
         isl_for_isl_can_validate: bool,
       },
       content: closed,


### PR DESCRIPTION
**Issue #, if available:**

#32 

**Description of changes:**

* Changes `invalid_schema` to `invalid_schemas`
* Updates all Ion Schema 1.0 tests to reflect that change
* Adds Ion Schema 2.0 test cases for invalid headers, footers, and Ion Schema version markers


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
