### PR TITLE
Adds flag to skip some Ion Schema 1.0 tests when running ISL for ISL.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# For .isl files, 2 space indentation
+[*.isl]
+indent_style = space
+indent_size = 2

--- a/ion_schema_1_0/constraints/byte_length/invalid.isl
+++ b/ion_schema_1_0/constraints/byte_length/invalid.isl
@@ -10,12 +10,19 @@ $test::{
     { byte_length: 5.2 },
     { byte_length: [0, 5] },
     { byte_length: range::[min, max] },
-    { byte_length: range::[1, 0] },
     { byte_length: range::[0] },
     { byte_length: range::[0, 1, 2] },
     { byte_length: range::[0d0, 1] },
     { byte_length: range::[0e0, 1] },
     { byte_length: range::[0, 1d0] },
     { byte_length: range::[0, 1e0] },
+  ]
+}
+
+$test::{
+  description: "byte_length range must be a valid, satisfiable range",
+  isl_for_isl_can_validate: false,
+  invalid_types: [
+    { byte_length: range::[1, 0] },
   ]
 }

--- a/ion_schema_1_0/constraints/codepoint_length/invalid.isl
+++ b/ion_schema_1_0/constraints/codepoint_length/invalid.isl
@@ -10,12 +10,19 @@ $test::{
     { codepoint_length: 5.2 },
     { codepoint_length: [0, 5] },
     { codepoint_length: range::[min, max] },
-    { codepoint_length: range::[1, 0] },
     { codepoint_length: range::[0] },
     { codepoint_length: range::[0, 1, 2] },
     { codepoint_length: range::[0d0, 1] },
     { codepoint_length: range::[0e0, 1] },
     { codepoint_length: range::[0, 1d0] },
     { codepoint_length: range::[0, 1e0] },
+  ]
+}
+
+$test::{
+  description: "codepoint_length range must be a valid, satisfiable range",
+  isl_for_isl_can_validate: false,
+  invalid_types: [
+    { codepoint_length: range::[1, 0] },
   ]
 }

--- a/ion_schema_1_0/constraints/container_length/invalid.isl
+++ b/ion_schema_1_0/constraints/container_length/invalid.isl
@@ -10,12 +10,19 @@ $test::{
     { container_length: 5.2 },
     { container_length: [0, 5] },
     { container_length: range::[min, max] },
-    { container_length: range::[1, 0] },
     { container_length: range::[1] },
     { container_length: range::[0, 1, 2] },
     { container_length: range::[0d0, 1] },
     { container_length: range::[0e0, 1] },
     { container_length: range::[0, 1d0] },
     { container_length: range::[0, 1e0] },
+  ]
+}
+
+$test::{
+  description: "container_length range must be a valid, satisfiable range",
+  isl_for_isl_can_validate: false,
+  invalid_types: [
+    { container_length: range::[1, 0] },
   ]
 }

--- a/ion_schema_1_0/constraints/occurs/invalid.isl
+++ b/ion_schema_1_0/constraints/occurs/invalid.isl
@@ -13,18 +13,27 @@ $test::{
     { occurs: {} },
     { occurs: [0, 1] },
     { occurs: range::[min, max] },
-    { occurs: range::[1, 0] },
     { occurs: range::[1] },
     { occurs: range::[0, 1, 2] },
     { occurs: range::[0d0, 1] },
     { occurs: range::[0e0, 1] },
     { occurs: range::[0, 1d0] },
     { occurs: range::[0, 1e0] },
+  ]
+}
+
+$test::{
+  description: "occurs range must be a valid, satisfiable range",
+  isl_for_isl_can_validate: false,
+  invalid_types: [
+    { occurs: range::[1, 0] },
     { occurs: range::[exclusive::1, exclusive::2] },
   ]
 }
+
 $test::{
   description: "occurs for a field must be a positive integer or a non-empty, non-negative integer range",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { fields: { a: { occurs: 0 } } },
     { fields: { a: { occurs: range::[0, 0] } } },

--- a/ion_schema_1_0/constraints/precision/invalid.isl
+++ b/ion_schema_1_0/constraints/precision/invalid.isl
@@ -10,12 +10,19 @@ $test::{
     { precision: 5.2 },
     { precision: [0, 5] },
     { precision: range::[min, max] },
-    { precision: range::[1, 0] },
     { precision: range::[1] },
     { precision: range::[1, 2, 3] },
     { precision: range::[0d0, 1] },
     { precision: range::[0e0, 1] },
     { precision: range::[0, 1d0] },
     { precision: range::[0, 1e0] },
+  ]
+}
+
+$test::{
+  description: "precision range must be a valid, satisfiable range",
+  isl_for_isl_can_validate: false,
+  invalid_types: [
+    { precision: range::[1, 0] },
   ]
 }

--- a/ion_schema_1_0/constraints/regex/invalid.isl
+++ b/ion_schema_1_0/constraints/regex/invalid.isl
@@ -13,6 +13,7 @@ $test::{
 
 $test::{
   description: "regex - backreferences are not allowed",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "\\1" }
   ]
@@ -20,6 +21,7 @@ $test::{
 
 $test::{
   description: "regex - POSIX character classes are not allowed",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "\\p{Lower}" }
   ]
@@ -27,6 +29,7 @@ $test::{
 
 $test::{
   description: "regex - invalid escaped character",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "\\A" },
     { regex: "\\b" },
@@ -48,6 +51,7 @@ $test::{
 
 $test::{
   description: "regex - invalid character classes/ranges",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "[a-d[m-p]]" },
     { regex: "[a-z&&[def]]" },
@@ -57,6 +61,7 @@ $test::{
 
 $test::{
   description: "regex - reluctant quantifiers are not allowed",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "abc??" },
     { regex: "abc*?" },
@@ -69,6 +74,7 @@ $test::{
 
 $test::{
   description: "regex - possessive quantifiers are not allowed",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "abc?+" },
     { regex: "abc*+" },
@@ -81,6 +87,7 @@ $test::{
 
 $test::{
   description: "regex - special constructs with prefix '(?' are not allowed",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { regex: "(?" }
   ]

--- a/ion_schema_1_0/constraints/scale/invalid.isl
+++ b/ion_schema_1_0/constraints/scale/invalid.isl
@@ -10,12 +10,19 @@ $test::{
     { scale: 5.2 },
     { scale: [0, 5] },
     { scale: range::[min, max] },
-    { scale: range::[1, 0] },
     { scale: range::[1] },
     { scale: range::[0, 1, 2] },
     { scale: range::[0d0, 1] },
     { scale: range::[0e0, 1] },
     { scale: range::[0, 1d0] },
     { scale: range::[0, 1e0] },
+  ]
+}
+
+$test::{
+  description: "scale range must be a valid, satisfiable range",
+  isl_for_isl_can_validate: false,
+  invalid_types: [
+    { scale: range::[1, 0] },
   ]
 }

--- a/ion_schema_1_0/constraints/timestamp_precision/invalid.isl
+++ b/ion_schema_1_0/constraints/timestamp_precision/invalid.isl
@@ -22,6 +22,7 @@ $test::{
 
 $test::{
   description: "timestamp_precision range - lower > upper",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { timestamp_precision: range::[max, min] },
     { timestamp_precision: range::[year, min] },
@@ -38,6 +39,7 @@ $test::{
 
 $test::{
   description: "timestamp_precision range - empty range",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { timestamp_precision: range::[exclusive::day, exclusive::day] }
   ]

--- a/ion_schema_1_0/constraints/utf8_byte_length/invalid.isl
+++ b/ion_schema_1_0/constraints/utf8_byte_length/invalid.isl
@@ -10,12 +10,19 @@ $test::{
     { utf8_byte_length: 5.2 },
     { utf8_byte_length: [0, 5] },
     { utf8_byte_length: range::[min, max] },
-    { utf8_byte_length: range::[1, 0] },
     { utf8_byte_length: range::[0] },
     { utf8_byte_length: range::[0, 1, 2] },
     { utf8_byte_length: range::[0d0, 1] },
     { utf8_byte_length: range::[0e0, 1] },
     { utf8_byte_length: range::[0, 1d0] },
     { utf8_byte_length: range::[0, 1e0] },
+  ]
+}
+
+$test::{
+  description: "utf8_byte_length range must be a valid, satisfiable range",
+  isl_for_isl_can_validate: false,
+  invalid_types: [
+    { utf8_byte_length: range::[1, 0] },
   ]
 }

--- a/ion_schema_1_0/constraints/valid_values/invalid.isl
+++ b/ion_schema_1_0/constraints/valid_values/invalid.isl
@@ -1,6 +1,6 @@
 $ion_schema_1_0
 $test::{
-  description: "valid_values must ba a list or range",
+  description: "valid_values must be a list or range",
   invalid_types: [
     { valid_values: null },
     { valid_values: null.int },
@@ -20,9 +20,17 @@ $test::{
 
 $test::{
   description: "valid_values ranges must be valid number or timestamp ranges",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { valid_values: range::[ 1, 0 ] },
     { valid_values: range::[ 0.00000000001, 0 ] },
+  ]
+}
+
+$test::{
+  description: "valid_values ranges must not have both min and max",
+  invalid_types: [
     { valid_values: range::[ min, max ] },
+    { valid_values: [range::[ min, max ]] },
   ]
 }

--- a/ion_schema_1_0/constraints/valid_values/range_timestamp_invalid.isl
+++ b/ion_schema_1_0/constraints/valid_values/range_timestamp_invalid.isl
@@ -1,11 +1,18 @@
 $ion_schema_1_0
 $test::{
-  description: "valid_values timestamp ranges must be valid ranges with a known local offset",
+  description: "valid_values timestamp ranges must have a known local offset",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { valid_values: range::[min, 2001T] },
     { valid_values: range::[exclusive::min, 2001T] },
     { valid_values: range::[2000T, max] },
     { valid_values: range::[2000T, exclusive::max] },
+  ]
+}
+$test::{
+  description: "valid_values timestamp ranges must be satisfiable ranges",
+  isl_for_isl_can_validate: false,
+  invalid_types: [
     { valid_values: range::[2000-01-01T00:00:00.000000001Z, 2000-01-01T00:00:00.000000000Z] },
     { valid_values: range::[exclusive::2000-01-01T00:00:00.000000000Z, 2000-01-01T00:00:00.000000000Z] },
     { valid_values: range::[2000-01-01T00:00:00.000000000Z, exclusive::2000-01-01T00:00:00.000000000Z] },

--- a/ion_schema_1_0/core_types/document.isl
+++ b/ion_schema_1_0/core_types/document.isl
@@ -23,6 +23,7 @@ $test::{
 
 $test::{
   description: "document cannot be nullable",
+  isl_for_isl_can_validate: false,
   invalid_types: [
     { type: nullable::document },
     { type: nullable::{ type: document } }

--- a/ion_schema_1_0/schema/import/import_type_unknown.isl
+++ b/ion_schema_1_0/schema/import/import_type_unknown.isl
@@ -2,6 +2,7 @@ $ion_schema_1_0
 
 $test::{
   description: "attempting to import an unknown type should result in an error",
+  isl_for_isl_can_validate: false,
   invalid_schemas: [ (
     schema_header::{
       imports: [


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

When working on #35, I missed some test cases that needed to be flagged as out of scope for ISL for ISL.

This PR causes ISL for ISL to skip invalid type tests for
* regexes (because there's no possible regular expression to validate regexes)
* all tests regarding ranges that are unsatisfiable
* tests for `document` not being allowed to be `nullable` (because ISL for Ion Schema 1.0 doesn't distinguish type names at all)

Also, skips an unknown import test case that was missed in the previous PR.

I meant to add the `.editorconfig` file in a separate PR since it is orthogonal to the test fixes, but I accidentally put it in here, so I'll leave it unless there's any objection.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
