### PR TITLE
Adds tests for Ion Schema 2.0 user content

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 This collection of files represents a test suite for implementations of the [Ion Schema Specifications](https://amzn.github.io/ion-schema/docs).
 This file describes how the tests are defined.
 
-There are three explicit and two implicit types of test cases.
+There are four explicit and two implicit types of test cases.
 
 1. `valid_schema` (implicit) – asserts that a schema document is valid.
-    Every test file should be a valid schema, so this is implied for every schema/file that is present in the test suite.
-2. `invalid_schemas` – asserts that each schema document in a given list of schema documents is invalid.
-3. `valid_type` – (implicit) asserts that a given type definition is valid.
-    Every top-level type in the test suite loaded and implicitly tested for validity. 
-4. `invalid_types` – asserts that each type in a given list of type definitions is invalid.
-5. `type`/`should_accept_as_valid`/`should_reject_as_invalid` – tests whether values match or do not match a given type.
+   Every test file should be a valid schema, so this is implied for every schema/file that is present in the test suite.
+2. `valid_schemas` – asserts that each schema document in a given list of schema documents is valid.
+3. `invalid_schemas` – asserts that each schema document in a given list of schema documents is invalid.
+4. `valid_type` – (implicit) asserts that a given type definition is valid.
+   Every top-level type in the test suite loaded and implicitly tested for validity. 
+5. `invalid_types` – asserts that each type in a given list of type definitions is invalid.
+6. `type`/`should_accept_as_valid`/`should_reject_as_invalid` – tests whether values match or do not match a given type.
 
 #### Implicit Tests
 Every `ion-schema-tests` test file should be an Ion Schema.
@@ -96,6 +97,31 @@ $test::{
 }
 ```
 
+#### `valid_schemas` Tests
+A test case that checks that the given schema documents are correctly recognized as valid.
+```ion
+$test::{
+  // A useful description of the test to aid with debugging, understanding the spec, etc.
+  description: "Unreserved symbols should always be permitted as user content field names in a schema header",
+
+  // Unlike `invalid_schemas` test cases, ISL for ISL cannot be skipped because ISL for ISL must always accept valid schemas.
+
+  // The actual schemas, embedded in a s-expression. Test runners must convert these s-expressions to a document.
+  valid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{ $lower_snake_case_with_a_leading_dollar_sign: 1 }
+      schema_footer::{} 
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ _lower_snake_case_with_a_leading_underscore: 2 }
+      schema_footer::{}
+    ),
+  ],
+}
+```
+
 #### `invalid_types` Tests
 A parameterized test case that checks that multiple type definitions are correctly recognized as invalid.
 Test runner implementations should append the zero-based index of the test case to the test description.
@@ -153,6 +179,12 @@ type::{
         description: { type: string, occurs: required },
         invalid_schemas: { type: list, occurs: required, element: sexp },
         isl_for_isl_can_validate: bool,
+      }
+    },
+    {
+      fields: closed::{
+        description: { type: string, occurs: required },
+        valid_schemas: { type: list, occurs: required, element: sexp },
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ A test case that checks that the given schema documents are correctly recognized
 ```ion
 $test::{
   // A useful description of the test to aid with debugging, understanding the spec, etc.
-  description: "Unreserved symbols should always be permitted as user content field names in a schema header",
+  description: "Unreserved symbols should always be permitted as open content field names in a schema header",
 
   // Unlike `invalid_schemas` test cases, ISL for ISL cannot be skipped because ISL for ISL must always accept valid schemas.
 

--- a/ion_schema_2_0/open_content/top_level_user_content.isl
+++ b/ion_schema_2_0/open_content/top_level_user_content.isl
@@ -1,0 +1,163 @@
+$ion_schema_2_0
+
+$test::{
+  description: "Top-level open content can appear anywhere in the schema document",
+  valid_schemas:[
+    (
+      "Non-ISL content can occur before the version marker,"
+      $ion_schema_2_0
+    ),
+    (
+      $ion_schema_2_0
+      "...between the version marker and header,"
+      schema_header::{}
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      "...between the header and a type,"
+      type::{ name: foo }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      "...between the version marker and a type,"
+      type::{ name: foo }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: foo }
+      "...between two types,"
+      type::{ name: bar }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{ name: foo }
+      "...between a type and the footer,"
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{}
+      "... or even after the footer."
+    ),
+  ]
+}
+
+$test::{
+  description: "Any type of Ion value can be top-level open content",
+  valid_schemas:[
+    ( $ion_schema_2_0 null ),
+    ( $ion_schema_2_0 true ),
+    ( $ion_schema_2_0 2000 ),
+    ( $ion_schema_2_0 3000e0 ),
+    ( $ion_schema_2_0 4000d0 ),
+    ( $ion_schema_2_0 5000T ),
+    ( $ion_schema_2_0 "abc" ),
+    ( $ion_schema_2_0 'DEF' ),
+    ( $ion_schema_2_0 {{ GHI= }} ),
+    ( $ion_schema_2_0 {{ "jkl" }} ),
+    ( $ion_schema_2_0 { a: 1 } ),
+    ( $ion_schema_2_0 [ 1, 2, 3 ] ),
+    ( $ion_schema_2_0 ( 1 2 3 ) ),
+  ]
+}
+
+$test::{
+  description: "Reserved symbols that are not version markers can be top-level user content",
+  valid_schemas: [
+    ( $ion_schema_2_0 so many reserved symbols right here ),
+    ( $ion_schema_2_0 ion_schema_2_0 ),
+    ( $ion_schema_2_0 $ion_schema_x_1 ),
+  ]
+}
+
+$test::{
+  description: "ISL keywords can be top-level user content",
+  valid_schemas:[
+    ( $ion_schema_2_0 all_of ),
+    ( $ion_schema_2_0 annotations ),
+    ( $ion_schema_2_0 any_of ),
+    ( $ion_schema_2_0 as ),
+    ( $ion_schema_2_0 byte_length ),
+    ( $ion_schema_2_0 codepoint_length ),
+    ( $ion_schema_2_0 container_length ),
+    ( $ion_schema_2_0 contains ),
+    ( $ion_schema_2_0 element ),
+    ( $ion_schema_2_0 exponent ),
+    ( $ion_schema_2_0 field_names ),
+    ( $ion_schema_2_0 fields ),
+    ( $ion_schema_2_0 id ),
+    ( $ion_schema_2_0 imports ),
+    ( $ion_schema_2_0 name ),
+    ( $ion_schema_2_0 not ),
+    ( $ion_schema_2_0 occurs ),
+    ( $ion_schema_2_0 one_of ),
+    ( $ion_schema_2_0 ordered_elements ),
+    ( $ion_schema_2_0 precision ),
+    ( $ion_schema_2_0 regex ),
+    ( $ion_schema_2_0 schema_footer ),
+    ( $ion_schema_2_0 schema_header ),
+    ( $ion_schema_2_0 timestamp_offset ),
+    ( $ion_schema_2_0 timestamp_precision ),
+    ( $ion_schema_2_0 type ),
+    ( $ion_schema_2_0 user_fields ),
+    ( $ion_schema_2_0 utf8_byte_length ),
+    ( $ion_schema_2_0 valid_values ),
+  ]
+}
+
+$test::{
+  // Ion Schema version markers are ^\$ion_schema_\d.*
+  // https://amzn.github.io/ion-schema/docs/isl-versioning#ion-schema-version-markers
+  description: "an Ion Schema version marker (even an invalid one) is never valid user content",
+  invalid_schemas:[
+    ( $ion_schema_2_0 $ion_schema_123_456 ),
+    ( $ion_schema_2_0 $ion_schema_2 ),
+    ( $ion_schema_2_0 $ion_schema_2_0_0 ),
+    ( $ion_schema_2_0 '$ion_schema_2.0' ),
+  ]
+}
+
+$test::{
+  description: "top-level user content may be annotated with any symbols that are not reserved symbols",
+  valid_schemas: [
+    ( $ion_schema_2_0 ''::0 ),
+    ( $ion_schema_2_0 $lower_snake_case_with_a_leading_dollar_sign::1 ),
+    ( $ion_schema_2_0 _lower_snake_case_with_leading_underscore::2 ),
+    ( $ion_schema_2_0 SCREAMING_SNAKE_CASE::3 ),
+    ( $ion_schema_2_0 'UPPER-KEBAB-CASE'::4 ),
+    ( $ion_schema_2_0 'lower-kebab-case'::5 ),
+    ( $ion_schema_2_0 camelCase::6 ),
+    ( $ion_schema_2_0 'annotation with whitespace'::7 ),
+    ( $ion_schema_2_0 '🥧_foo'::8 ),
+    ( $ion_schema_2_0 'é∑å®ê'::9 ),
+    ( $ion_schema_2_0 _::10 ),
+    ( $ion_schema_2_0 $::11 ),
+    ( $ion_schema_2_0 'éomer'::12 ),
+    ( $ion_schema_2_0 $ion_schemabutnotreally::13 ),
+    ( $ion_schema_2_0 Multiple::_annotations::$are::OK::"too" ),
+  ]
+}
+
+$test::{
+  description: "top-level user content may not be annotated with any reserved symbols",
+  invalid_schemas:[
+    ( $ion_schema_2_0 $ion_schema::1 ),
+    ( $ion_schema_2_0 $ion_schema_abc::1 ),
+    ( $ion_schema_2_0 $ion_schema_2_0::1 ),
+    ( $ion_schema_2_0 lower_snake_case::1 ),
+    // Even if there's an unreserved symbol, the reserved symbol still makes this invalid
+    ( $ion_schema_2_0 _foo::bar::1 ),
+  ]
+}
+
+$test::{
+  description: "an annotated Ion Schema version marker is not valid ",
+  invalid_schemas:[
+    ( $ion_schema_2_0 _foo::$ion_schema_2_0 )
+  ]
+}

--- a/ion_schema_2_0/open_content/user_fields_declaration.isl
+++ b/ion_schema_2_0/open_content/user_fields_declaration.isl
@@ -1,0 +1,656 @@
+$ion_schema_2_0
+
+$test::{
+  description: "user_fields declaration must be a non-null, unannotated struct",
+  invalid_schemas:[
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: a_symbol }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: null.struct }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: [a, b, c] }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: foo::{} }
+      schema_footer::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "user_fields declaration may not have unexpected fields",
+  invalid_schemas:[
+    (
+      $ion_schema_2_0
+      schema_header::{
+        type: [a, b, c],
+        // 'foo' is not one of the allowed fields in the user_fields struct
+        foo: [d, e, f],
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{
+        type: [a, b, c],
+        // Not even unreserved field names.
+        $Foo: [d, e, f],
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{
+        type: [a, b, c],
+        // Unexpected repetition of the field name
+        type: [d, e, f],
+      }
+      schema_footer::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "user_fields declaration fields must be an unannotated, non-null list",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: (a b c), } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: foo::[a, b, c], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: null.list, } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: (a b c), } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: foo::[a, b, c], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: null.list, } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: (a b c), } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: foo::[a, b, c], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: null.list, } }
+      schema_footer::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "declared user_fields symbols must be non-null, unannotated symbols",
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [foo::a, b, c], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: ["abc"], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [null.symbol], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [null], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [a, foo::b, c], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: ["abc"], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [null.symbol], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [null], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [a, b, foo::c], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: ["abc"], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [null.symbol], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [null], } }
+      schema_footer::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "user_fields declaration may have empty containers",
+  valid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [], } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [], } }
+      schema_footer::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "ISL 2.0 keywords may not be declared as user fields for the schema header",
+  invalid_schemas:[
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ all_of ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ annotations ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ any_of ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ as ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ byte_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ codepoint_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ container_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ contains ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ element ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ exponent ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ field_names ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ fields ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ id ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ imports ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ name ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ not ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ occurs ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ one_of ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ ordered_elements ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ precision ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ regex ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ schema_footer ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ schema_header ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ timestamp_offset ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ timestamp_precision ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ type ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ user_fields ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ utf8_byte_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [ valid_values ] } }
+      schema_footer::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "ISL 2.0 keywords may not be declared as user fields for type definitions",
+  invalid_schemas:[
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ all_of ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ annotations ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ any_of ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ as ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ byte_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ codepoint_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ container_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ contains ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ element ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ exponent ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ field_names ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ fields ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ id ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ imports ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ name ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ not ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ occurs ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ one_of ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ ordered_elements ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ precision ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ regex ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ schema_footer ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ schema_header ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ timestamp_offset ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ timestamp_precision ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ type ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ user_fields ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ utf8_byte_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [ valid_values ] } }
+      schema_footer::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "ISL 2.0 keywords may not be declared as user fields for the schema footer",
+  invalid_schemas:[
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ all_of ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ annotations ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ any_of ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ as ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ byte_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ codepoint_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ container_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ contains ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ element ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ exponent ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ field_names ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ fields ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ id ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ imports ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ name ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ not ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ occurs ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ one_of ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ ordered_elements ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ precision ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ regex ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ schema_footer ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ schema_header ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ timestamp_offset ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ timestamp_precision ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ type ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ user_fields ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ utf8_byte_length ] } }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [ valid_values ] } }
+      schema_footer::{}
+    ),
+  ]
+}

--- a/ion_schema_2_0/open_content/user_fields_in_schema_footer.isl
+++ b/ion_schema_2_0/open_content/user_fields_in_schema_footer.isl
@@ -1,0 +1,130 @@
+$ion_schema_2_0
+
+$test::{
+  description: "Unreserved symbols should always be permitted as user field names in a schema footer",
+  valid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ '': 0 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ $lower_snake_case_with_a_leading_dollar_sign: 1 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ _lower_snake_case_with_leading_underscore: 2 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ SCREAMING_SNAKE_CASE: 3 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ 'UPPER-KEBAB-CASE': 4 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ 'lower-kebab-case': 5 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ camelCase: 6 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ 'name with whitespace': 7 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ '🥧_foo': 8 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ 'é∑å®ê': 9 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ _: 10 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ $: 11 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ 'éomer': 12 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ $ion_schemabutnotreally: 13 }
+    ),
+  ]
+}
+
+$test::{
+  description: "Reserved symbols that are not declared as user fields should not be permitted as user field names in the schema footer",
+  isl_for_isl_can_validate: false,
+  invalid_schemas:[
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ $ion_schema: 1 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ $ion_schema_abc: 1 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ $ion_schema_2_0: 1 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      schema_footer::{ lower_snake_case: 1 }
+    ),
+  ]
+}
+
+$test::{
+  description: "Any symbols that are declared as user fields for the schema footer should be permitted as field names in the schema footer",
+  valid_schemas:[
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [$ion_schema] } }
+      schema_footer::{ $ion_schema: 1 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [$ion_schema_abc] } }
+      schema_footer::{ $ion_schema_abc: 1 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [$ion_schema_2_0] } }
+      schema_footer::{ $ion_schema_2_0: 1 }
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_footer: [lower_snake_case] } }
+      schema_footer::{ lower_snake_case: 1 }
+    ),
+  ]
+}

--- a/ion_schema_2_0/open_content/user_fields_in_schema_header.isl
+++ b/ion_schema_2_0/open_content/user_fields_in_schema_header.isl
@@ -1,0 +1,130 @@
+$ion_schema_2_0
+
+$test::{
+  description: "Unreserved symbols should always be permitted as user field names in a schema header",
+  valid_schemas: [
+    (
+      $ion_schema_2_0
+      schema_header::{ '': 0 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ $lower_snake_case_with_a_leading_dollar_sign: 1 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ _lower_snake_case_with_leading_underscore: 2 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ SCREAMING_SNAKE_CASE: 3 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ 'UPPER-KEBAB-CASE': 4 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ 'lower-kebab-case': 5 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ camelCase: 6 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ 'name with whitespace': 7 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ '🥧_foo': 8 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ 'é∑å®ê': 9 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ _: 10 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ $: 11 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ 'éomer': 12 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ $ion_schemabutnotreally: 13 }
+      schema_footer::{}
+    ),
+  ]
+}
+
+$test::{
+  description: "Reserved symbols that are not declared as user fields should not be a legal field name in the schema header",
+  isl_for_isl_can_validate: false,
+  invalid_schemas:[
+    (
+      $ion_schema_2_0
+      schema_header::{ $ion_schema: 1 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ $ion_schema_abc: 1 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ $ion_schema_2_0: 1 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ lower_snake_case: 1 }
+      schema_footer::{}
+    )
+  ]
+}
+
+$test::{
+  description: "Any symbols that are declared as user fields for the schema header should be permitted as field names in the schema header",
+  valid_schemas:[
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [$ion_schema] }, $ion_schema: 1 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [$ion_schema_abc] }, $ion_schema_abc: 1 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [$ion_schema_2_0] }, $ion_schema_2_0: 1 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { schema_header: [lower_snake_case] }, lower_snake_case: 1 }
+      schema_footer::{}
+    ),
+  ]
+}

--- a/ion_schema_2_0/open_content/user_fields_in_type_definition.isl
+++ b/ion_schema_2_0/open_content/user_fields_in_type_definition.isl
@@ -1,0 +1,180 @@
+$ion_schema_2_0
+
+$test::{
+  description: "Unreserved symbols should always be permitted as user field names in a type definition",
+  valid_schemas: [
+    (
+      $ion_schema_2_0
+      type::{ name: type_0, '': 0, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_1, $lower_snake_case_with_a_leading_dollar_sign: 1, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_2, _lower_snake_case_with_leading_underscore: 2, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_3, SCREAMING_SNAKE_CASE: 3, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_4, 'UPPER-KEBAB-CASE': 4, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_5, 'lower-kebab-case': 5, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_6, camelCase: 6, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_7, 'name with whitespace': 7, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_8, '🥧_foo': 8, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_9, 'é∑å®ê': 9, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_10, _: 10, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_11, $: 11, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_12, 'éomer': 12, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{ name: type_13, $ion_schemabutnotreally: 13, }
+    ),
+    (
+      $ion_schema_2_0
+      type::{
+        name: type_14,
+        // User fields in an inline type definition
+        element: { _lorem_ipsum: 1 },
+      }
+    ),
+    (
+      $ion_schema_2_0
+      type::{
+        name: type_15,
+        fields: {
+          foo: {
+            // User field in a variably-occuring type definition
+            occurs: required,
+            _lorem_ipsum: 1
+          }
+        },
+      }
+    ),
+  ],
+}
+
+$test::{
+  description: "Reserved symbols that are not declared as user fields should not be a legal field name in the type definition",
+  isl_for_isl_can_validate: false,
+  invalid_schemas:[
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: type_with_illegal_field_name,
+        $ion_schema: 1
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: type_with_illegal_field_name,
+        $ion_schema_abc: 1
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: type_with_illegal_field_name,
+        $ion_schema_2_0: 1
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{}
+      type::{
+        name: type_with_illegal_field_name,
+        lower_snake_case: 1
+      }
+      schema_footer::{}
+    )
+  ]
+}
+
+$test::{
+  description: "Any symbols that are declared as user fields for type definitions should be permitted as field names in a type definition",
+  valid_schemas:[
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [$ion_schema] } }
+      type::{ name: type_with_legal_field_name, $ion_schema: 1 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [$ion_schema_abc] } }
+      type::{ name: type_with_legal_field_name, $ion_schema_abc: 1 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [$ion_schema_2_0] } }
+      type::{ name: type_with_legal_field_name, $ion_schema_2_0: 1 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [lower_snake_case] } }
+      type::{ name: type_with_legal_field_name, lower_snake_case: 1 }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [lower_snake_case] } }
+      type::{
+        name: type_with_legal_field_name_in_nested_definition,
+        element: { lower_snake_case: 1 },
+      }
+      schema_footer::{}
+    ),
+    (
+      $ion_schema_2_0
+      schema_header::{ user_fields: { type: [lower_snake_case] } }
+      type::{
+        name: type_with_legal_field_name_in_variably_occuring_type_definition,
+        fields: {
+          foo: {
+            occurs: required,
+            lower_snake_case: 1
+          }
+        },
+      }
+      schema_footer::{}
+    ),
+  ]
+}

--- a/ion_schema_2_0/schema/schema_footer.isl
+++ b/ion_schema_2_0/schema/schema_footer.isl
@@ -89,7 +89,7 @@ $test::{
       schema_footer::schema_header::{}
     ),
     (
-    $ion_schema_2_0
+      $ion_schema_2_0
       schema_header::{}
       type::{
         name: foo,
@@ -143,7 +143,7 @@ $test::{
       schema_footer::()
     ),
     (
-    $ion_schema_2_0
+      $ion_schema_2_0
       schema_header::{}
       type::{
         name: foo,

--- a/ion_schema_2_0/schema/type.isl
+++ b/ion_schema_2_0/schema/type.isl
@@ -83,7 +83,7 @@ $test::{
       type::{ name: "foo" }
     ),
     (
-    $ion_schema_2_0
+      $ion_schema_2_0
       type::{ name: null }
     ),
     (

--- a/ion_schema_tests.isl
+++ b/ion_schema_tests.isl
@@ -24,6 +24,13 @@ type::{
     {
       fields: {
         description: { type: string, occurs: required },
+        valid_schemas: { type: list, occurs: required, element: sexp },
+      },
+      content: closed,
+    },
+    {
+      fields: {
+        description: { type: string, occurs: required },
         invalid_types: { type: list, occurs: required },
         isl_for_isl_can_validate: bool,
       },


### PR DESCRIPTION
**Issue #, if available:**

#32 

**Description of changes:**

* [Adds valid_schemas test case type](https://github.com/amzn/ion-schema-tests/commit/38bd815af056e891f0383df31b67cae0cad94100)
  * I realized that it would be helpful to have a way to assert that many schemas are valid without having to manage a separate file for each test case. I don't want "too many files" to discourage anyone from creating good test coverage.
  * We don't need a `valid_types` test case because you can have more than one type in a schema document.
* [Adds test cases for Ion Schema 2.0 user content](https://github.com/amzn/ion-schema-tests/commit/05f7a34e7bba567ddc4ec99337cc41daa48eab5b)
  * Includes test cases for user content in the schema header, schema footer, and type definitions as well as top-level user content
  * Includes test cases for user content declarations in the schema header

There's also a couple of unrelated formatting fixes that made it in (fixing indentation).

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
