### PR TITLE
Adds more tests cases for Ion Schema 2.0 types

### DIFF
--- a/ion_schema_2_0/schema/schema_with_circularly_referencing_types.isl
+++ b/ion_schema_2_0/schema/schema_with_circularly_referencing_types.isl
@@ -1,0 +1,46 @@
+$ion_schema_2_0
+
+// The purpose of this test is to ensure that implementations can properly load circularly referencing types
+// There are a few value-based test cases just to make sure that the implementation doesn't fail when you
+// actually try to use the types.
+
+type::{
+  name: struct_of_lists,
+  type: struct,
+  element: list_of_structs
+}
+
+type::{
+  name: list_of_structs,
+  type: list,
+  element: struct_of_lists,
+}
+
+$test::{
+  type: struct_of_lists,
+  should_accept_as_valid: [
+    {},
+    { a: [] },
+    { a: [], b: [] },
+    { a: [ { b: [ { c: [] }] } ] },
+  ],
+  should_reject_as_invalid: [
+    [],
+    { a: { b: [] } },
+  ],
+}
+
+$test::{
+  type: list_of_structs,
+  should_accept_as_valid: [
+    [],
+    [{}],
+    [{ a: [] } ],
+    [{ a: [ { b: [ { c: [] } ] } ] } ],
+  ],
+  should_reject_as_invalid: [
+    {},
+    [ [ { a: [] } ] ],
+    { a: [ [] ] },
+  ],
+}

--- a/ion_schema_2_0/schema/schema_with_recursive_type.isl
+++ b/ion_schema_2_0/schema/schema_with_recursive_type.isl
@@ -1,0 +1,32 @@
+$ion_schema_2_0
+
+// The purpose of this test is to ensure that implementations can properly load self-referencing/recursive types
+// There are a few value-based test cases just to make sure that the implementation doesn't fail when you
+// actually try to use the type.
+
+type::{
+  name: sexpression_tree,
+  ordered_elements: [
+    symbol,
+    {
+      type: sexpression_tree,
+      occurs: range::[0, max],
+    },
+  ]
+}
+
+$test::{
+  type: sexpression_tree,
+  should_accept_as_valid: [
+    (a),
+    (a (b)),
+    (a (b) (c) (d)),
+    (a (b (c (d)))),
+  ],
+  should_reject_as_invalid: [
+    (),
+    (a b),
+    (a (b c)),
+    (a ()),
+  ],
+}

--- a/ion_schema_2_0/schema/schema_with_type_referenced_before_it_is_defined.isl
+++ b/ion_schema_2_0/schema/schema_with_type_referenced_before_it_is_defined.isl
@@ -1,0 +1,35 @@
+$ion_schema_2_0
+
+// The purpose of this test is to ensure that implementations can properly load when types are referenced before
+// they are defined. There are a few value-based test cases just to make sure that the implementation doesn't
+// fail when you actually try to use the types.
+
+type::{
+  name: a_type,
+  fields: {
+    // Neither of these types are defined yet
+    b: b_type,
+    c: c_type,
+  },
+}
+
+type::{
+  name: b_type,
+  type: list,
+  element: c_type, // c_type is still not defined
+}
+
+type::{
+  name: c_type,
+  type: int,
+  valid_values: range::[0, max],
+}
+
+$test::{
+  type: a_type,
+  should_accept_as_valid: [
+    {},
+    {b: [1]},
+    {b: [1, 2], c: 3},
+  ],
+}

--- a/ion_schema_2_0/schema/type.isl
+++ b/ion_schema_2_0/schema/type.isl
@@ -96,3 +96,21 @@ $test::{
     ),
   ],
 }
+
+$test::{
+  description: "Type names may not be repeated in a single schema document",
+  isl_for_isl_can_validate: false,
+  invalid_schemas: [
+    (
+      $ion_schema_2_0
+      type::{ name: foo, type: int }
+      type::{ name: foo, type: string }
+    ),
+    // Even when the types are identical, it's still invalid
+    (
+      $ion_schema_2_0
+      type::{ name: foo }
+      type::{ name: foo }
+    ),
+  ],
+}


### PR DESCRIPTION
**Issue #, if available:**

#32 

**Description of changes:**

Adds test cases for:
* no duplicate type names in a schema
* deferred resolution of type references
* recursive type definition
* circularly referencing type definitions


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
