### PR TITLE
Improves test names

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,16 @@ type::{
 
 #### `type`/`should_accept_as_valid`/`should_reject_as_invalid` Tests
 A test case that checks to see if certain values match a type.
+The type name should be descriptive of the specific functionality being tested.
 ```ion
 type::{
-  name: short_string,
+  name: string_with_codepoint_length_range,
   type: string,
   codepoint_length: range::[0, 10],
 }
 
 $test::{
-  type: short_string,
+  type: string_with_codepoint_length_range,
   should_accept_as_valid: [
     "",
     "Hello!",

--- a/ion_schema_2_0/constraints/annotations-simplified.isl
+++ b/ion_schema_2_0/constraints/annotations-simplified.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'annotations: closed::[foo, bar]',
+  name: closed_annotations,
   annotations: closed::[foo, bar],
 }
 
 $test::{
-  type: 'annotations: closed::[foo, bar]',
+  type: closed_annotations,
   should_accept_as_valid: [
     0,
     foo::1,
@@ -27,12 +27,12 @@ $test::{
 
 type::{
   // Important use case—no annotations allowed
-  name: 'annotations: closed::[]',
+  name: closed_no_annotations,
   annotations: closed::[],
 }
 
 $test::{
-  type: 'annotations: closed::[]',
+  type: closed_no_annotations,
   should_accept_as_valid: [
     0,
     true,
@@ -49,12 +49,12 @@ $test::{
 }
 
 type::{
-  name: 'annotations: required::[foo, bar]',
+  name: required_annotations,
   annotations: required::[foo, bar],
 }
 
 $test::{
-  type: 'annotations: required::[foo, bar]',
+  type: required_annotations,
   should_accept_as_valid: [
     foo::bar::1,
     bar::foo::2,
@@ -75,12 +75,12 @@ $test::{
 }
 
 type::{
-  name: 'annotations: closed::required::[foo, bar]',
+  name: closed_and_required_annotations,
   annotations: closed::required::[foo, bar],
 }
 
 $test::{
-  type: 'annotations: closed::required::[foo, bar]',
+  type: closed_and_required_annotations,
   should_accept_as_valid: [
     foo::bar::1,
     bar::foo::2,

--- a/ion_schema_2_0/constraints/annotations-standard.isl
+++ b/ion_schema_2_0/constraints/annotations-standard.isl
@@ -6,12 +6,12 @@ type::{
 }
 
 type::{
-  name: 'annotations: { element: only_vowels }',
+  name: annotations_with_regex,
   annotations: { element: only_vowels },
 }
 
 $test::{
-  type: 'annotations: { element: only_vowels }',
+  type: annotations_with_regex,
   should_accept_as_valid: [
     0,
     ''::0,
@@ -31,12 +31,12 @@ $test::{
 
 type::{
   // Important use case—exactly N annotations allowed
-  name: 'annotations: { container_length: 1 }',
+  name: exactly_n_annotations_allowed,
   annotations: { container_length: 1 },
 }
 
 $test::{
-  type: 'annotations: { container_length: 1 }',
+  type: exactly_n_annotations_allowed,
   should_accept_as_valid: [
     a::0,
     $b::1,

--- a/ion_schema_2_0/constraints/byte_length.isl
+++ b/ion_schema_2_0/constraints/byte_length.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'byte_length: 5',
+  name: byte_length_with_single_value,
   byte_length: 5,
 }
 
 $test::{
-  type: 'byte_length: 5',
+  type: byte_length_with_single_value,
   should_accept_as_valid: [
     {{"12345"}},
     {{ aGVsbG8= }},
@@ -25,12 +25,12 @@ $test::{
 }
 
 type::{
-  name: 'byte_length: range::[5, 10]',
+  name: byte_length_with_range,
   byte_length: range::[5, 10],
 }
 
 $test::{
-  type: 'byte_length: range::[5, 10]',
+  type: byte_length_with_range,
   should_accept_as_valid:[
     {{"12345"}},
     {{"1234567890"}},
@@ -84,7 +84,7 @@ $test::{
 }
 
 $test::{
-  description: "byte_length range must not be non-empty",
+  description: "byte_length range must be satisfiable",
   isl_for_isl_can_validate: false,
   invalid_types:[
     { byte_length: range::[2, 1] },

--- a/ion_schema_2_0/constraints/codepoint_length.isl
+++ b/ion_schema_2_0/constraints/codepoint_length.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'codepoint_length: 5',
+  name: codepoint_length_with_single_value,
   codepoint_length: 5,
 }
 
 $test::{
-  type: 'codepoint_length: 5',
+  type: codepoint_length_with_single_value,
   should_accept_as_valid: [
     '12345',
     "12345",
@@ -20,12 +20,12 @@ $test::{
 }
 
 type::{
-  name: 'codepoint_length: range::[5, 10]',
+  name: codepoint_length_with_range,
   codepoint_length: range::[5, 10],
 }
 
 $test::{
-  type: 'codepoint_length: range::[5, 10]',
+  type: codepoint_length_with_range,
   should_accept_as_valid:[
     '12345',
     "1234567890",
@@ -72,7 +72,7 @@ $test::{
 }
 
 $test::{
-  description: "codepoint_length range must not be non-empty",
+  description: "codepoint_length range must be satisfiable",
   isl_for_isl_can_validate: false,
   invalid_types:[
     { codepoint_length: range::[2, 1] },

--- a/ion_schema_2_0/constraints/container_length.isl
+++ b/ion_schema_2_0/constraints/container_length.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'container_length: 5',
+  name: container_length_with_single_value,
   container_length: 5,
 }
 
 $test::{
-  type: 'container_length: 5',
+  type: container_length_with_single_value,
   should_accept_as_valid: [
     [1, 2, 3, 4, 5],
     (a b c d e),
@@ -30,12 +30,12 @@ $test::{
 }
 
 type::{
-  name: 'container_length: range::[5, 10]',
+  name: container_length_with_range,
   container_length: range::[5, 10],
 }
 
 $test::{
-  type: 'container_length: range::[5, 10]',
+  type: container_length_with_range,
   should_accept_as_valid:[
     [1, 2, 3, 4, 5],
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
@@ -95,7 +95,7 @@ $test::{
 }
 
 $test::{
-  description: "container_length range must not be non-empty",
+  description: "container_length range must be satisfiable",
   isl_for_isl_can_validate: false,
   invalid_types:[
     { container_length: range::[2, 1] },

--- a/ion_schema_2_0/constraints/contains.isl
+++ b/ion_schema_2_0/constraints/contains.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'contains: []',
+  name: contains_with_empty_arg_list,
   contains: [],
 }
 
 $test::{
-  type: 'contains: []',
+  type: contains_with_empty_arg_list,
   // Should match any non-null container type
   should_accept_as_valid:[
     (),
@@ -25,13 +25,13 @@ $test::{
 }
 
 type::{
-  name: 'contains: [true, 1, a, null]',
+  name: contains_with_non_empty_arg_list,
   contains: [true, 1, a, null],
 }
 
 $test::{
   // Test various "normal" values.
-  type: 'contains: [true, 1, a, null]',
+  type: contains_with_non_empty_arg_list,
   should_accept_as_valid:[
     [true, 1, a, null],
     [a, null, 1, true],
@@ -56,12 +56,12 @@ $test::{
 }
 
 type::{
-  name: 'contains: [[a]]',
+  name: contains_with_nested_list,
   contains: [[a]],
 }
 
 $test::{
-  type: 'contains: [[a]]',
+  type: contains_with_nested_list,
   should_accept_as_valid:[
     [true, [a]],
     [[a]],
@@ -77,12 +77,12 @@ $test::{
 }
 
 type::{
-  name: 'contains: [1, 1]',
+  name: contains_with_duplicate_elements,
   contains: [1, 1],
 }
 
 $test::{
-  type: 'contains: [1, 1]',
+  type: contains_with_duplicated_value,
   should_accept_as_valid:[
     [1],
     [1, 2, 3],
@@ -96,12 +96,12 @@ $test::{
 }
 
 type::{
-  name: 'contains: [foo::bar::1]',
+  name: contains_with_annotated_value,
   contains: [foo::bar::1],
 }
 
 $test::{
-  type: 'contains: [foo::bar::1]',
+  type: contains_with_annotated_value,
   should_accept_as_valid:[
     [foo::bar::1],
     [+inf, foo::bar::1, abc, null],

--- a/ion_schema_2_0/constraints/element.isl
+++ b/ion_schema_2_0/constraints/element.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'element: int',
+  name: element_with_named_type,
   element: int,
 }
 
 $test::{
-  type: 'element: int',
+  type: element_with_named_type,
   should_accept_as_valid: [
     [],
     [1],
@@ -37,12 +37,12 @@ $test::{
 }
 
 type::{
-  name: 'element: $null_or::number',
+  name: element_with_nullable_type,
   element: $null_or::number,
 }
 
 $test::{
-  type: 'element: $null_or::number',
+  type: element_with_nullable_type,
   should_accept_as_valid: [
     {},
     [1, 2.0, 3e2, nan],
@@ -60,12 +60,12 @@ $test::{
 }
 
 type::{
-  name: 'element: distinct::$int',
+  name: element_with_distinct_modifier,
   element: distinct::$int,
 }
 
 $test::{
-  type: 'element: distinct::$int',
+  type: element_with_distinct_modifier,
   should_accept_as_valid: [
     [],
     [1],
@@ -94,12 +94,12 @@ $test::{
 }
 
 type::{
-  name: 'element: nothing',
+  name: element_nothing,
   element: nothing,
 }
 
 $test::{
-  type: 'element: nothing',
+  type: element_nothing,
   should_accept_as_valid: [
     {},
     [],

--- a/ion_schema_2_0/constraints/exponent.isl
+++ b/ion_schema_2_0/constraints/exponent.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'exponent: -2',
+  name: exponent_with_single_value,
   exponent: -2,
 }
 
 $test::{
-  type: 'exponent: -2',
+  type: exponent_with_single_value,
   should_accept_as_valid:[
     0.42,
     4.2d-1,
@@ -26,12 +26,12 @@ $test::{
 }
 
 type::{
-  name: 'exponent: range::[-4, 2]',
+  name: exponent_with_range,
   exponent: range::[-4, 2],
 }
 
 $test::{
-  type: 'exponent: range::[-4, 2]',
+  type: exponent_with_range,
   should_accept_as_valid:[
     42d2,
     42d1,
@@ -76,7 +76,7 @@ $test::{
 }
 
 $test::{
-  description: "exponent range must not be non-empty",
+  description: "exponent range must be satisfiable",
   isl_for_isl_can_validate: false,
   invalid_types:[
     { exponent: range::[2, 1] },

--- a/ion_schema_2_0/constraints/not.isl
+++ b/ion_schema_2_0/constraints/not.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'not: any',
+  name: not_named_type,
   not: any,
 }
 
 $test::{
-  type: 'not: any',
+  type: not_named_type,
   should_accept_as_valid: [
     null,
     null.bool,

--- a/ion_schema_2_0/constraints/precision.isl
+++ b/ion_schema_2_0/constraints/precision.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'precision: 2',
+  name: precision_with_single_value,
   precision: 2,
 }
 
 $test::{
-  type: 'precision: 2',
+  type: precision_with_single_value,
   should_accept_as_valid:[
     0.42,
     4.2d-1,
@@ -24,12 +24,12 @@ $test::{
 }
 
 type::{
-  name: 'precision: range::[2, 4]',
+  name: precision_with_range,
   precision: range::[2, 4],
 }
 
 $test::{
-  type: 'precision: range::[2, 4]',
+  type: precision_with_range,
   should_accept_as_valid:[
     42d10,
     42d2,
@@ -85,7 +85,7 @@ $test::{
 }
 
 $test::{
-  description: "precision range must not be non-empty",
+  description: "precision range must be satisfiable",
   isl_for_isl_can_validate: false,
   invalid_types:[
     { precision: range::[2, 1] },

--- a/ion_schema_2_0/constraints/timestamp_offset.isl
+++ b/ion_schema_2_0/constraints/timestamp_offset.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'timestamp_offset: ["+02:43"]',
+  name: timestamp_offset_with_non_zero_offset,
   timestamp_offset: ["+02:43"],
 }
 
 $test::{
-  type: 'timestamp_offset: ["+02:43"]',
+  type: timestamp_offset_with_non_zero_offset,
   should_accept_as_valid:[
     2000-01-01T00:00+02:43,
     2000-01-01T00:00:00+02:43,
@@ -44,12 +44,12 @@ $test::{
 }
 
 type::{
-  name: 'timestamp_offset: ["-00:00"]',
+  name: timestamp_offset_unknown_offset,
   timestamp_offset: ["-00:00"],
 }
 
 $test::{
-  type: 'timestamp_offset: ["-00:00"]',
+  type: timestamp_offset_unknown_offset,
   should_accept_as_valid:[
     2000T,
     2001-02-03T,
@@ -65,12 +65,12 @@ $test::{
 }
 
 type::{
-  name: 'timestamp_offset: ["+00:00"]',
+  name: timestamp_offset_utc_offset,
   timestamp_offset: ["+00:00"],
 }
 
 $test::{
-  type: 'timestamp_offset: ["+00:00"]',
+  type: timestamp_offset_utc_offset,
   should_accept_as_valid:[
     2000-01-01T00:00+00:00,
     2000-01-01T12:34:56.789Z,
@@ -87,12 +87,12 @@ $test::{
 }
 
 type::{
-  name: 'timestamp_offset: ["+01:23", "-02:34"]',
+  name: timestamp_offset_with_multiple_different_offsets,
   timestamp_offset: ["+01:23", "-02:34"],
 }
 
 $test::{
-  type: 'timestamp_offset: ["+01:23", "-02:34"]',
+  type: timestamp_offset_with_multiple_different_offsets,
   should_accept_as_valid:[
     2000-01-01T00:00+01:23,
     2000-01-01T12:34:56.789-02:34,

--- a/ion_schema_2_0/constraints/timestamp_precision.isl
+++ b/ion_schema_2_0/constraints/timestamp_precision.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'timestamp_precision: month',
+  name: timestamp_precision_with_single_value,
   timestamp_precision: month,
 }
 
 $test::{
-  type: 'timestamp_precision: month',
+  type: timestamp_precision_with_single_value,
   should_accept_as_valid:[
     2022-01T,
     1999-12T,
@@ -22,12 +22,12 @@ $test::{
 }
 
 type::{
-  name: 'timestamp_precision: range::[day, second]',
+  name: timestamp_precision_with_range,
   timestamp_precision: range::[day, second],
 }
 
 $test::{
-  type: 'timestamp_precision: range::[day, second]',
+  type: timestamp_precision_with_range,
   should_accept_as_valid:[
     2022-03-04T05:06:07Z,
     2022-03-04T05:06:07-00:00,
@@ -45,12 +45,12 @@ $test::{
 }
 
 type::{
-  name: 'timestamp_precision: range::[exclusive::second, exclusive::millisecond]',
+  name: timestamp_precision_with_range_exclusively_between_two_consecutive_named_precisions,
   timestamp_precision: range::[exclusive::second, exclusive::millisecond],
 }
 
 $test::{
-  type: 'timestamp_precision: range::[exclusive::second, exclusive::millisecond]',
+  type: timestamp_precision_with_range_exclusively_between_two_consecutive_named_precisions,
   should_accept_as_valid:[
     2022-03-04T05:06:07.0Z,
     2022-03-04T05:06:07.00Z,
@@ -72,12 +72,12 @@ $test::{
 }
 
 type::{
-  name: 'timestamp_precision: range::[exclusive::nanosecond, max]',
+  name: timestamp_precision_with_range_exclusively_greater_than_nanosecond,
   timestamp_precision: range::[exclusive::nanosecond, max],
 }
 
 $test::{
-  type: 'timestamp_precision: range::[exclusive::nanosecond, max]',
+  type: timestamp_precision_with_range_exclusively_greater_than_nanosecond,
   should_accept_as_valid:[
     2022-03-04T05:06:07.0000000000Z,
     2022-03-04T05:06:07.00000000000Z,
@@ -112,7 +112,7 @@ $test::{
 }
 
 $test::{
-  description: "timestamp_precision range must not be non-empty",
+  description: "timestamp_precision range must be satisfiable",
   isl_for_isl_can_validate: false,
   invalid_types:[
     { timestamp_precision: range::[exclusive::minute, exclusive::second] },

--- a/ion_schema_2_0/constraints/type.isl
+++ b/ion_schema_2_0/constraints/type.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'type: any',
+  name: type_named_type,
   type: any,
 }
 
 $test::{
-  type: 'type: any',
+  type: type_named_type,
   should_accept_as_valid: [
     true,
     1,

--- a/ion_schema_2_0/constraints/utf8_byte_length.isl
+++ b/ion_schema_2_0/constraints/utf8_byte_length.isl
@@ -1,12 +1,12 @@
 $ion_schema_2_0
 
 type::{
-  name: 'utf8_byte_length: 5',
+  name: utf8_byte_length_with_single_value,
   utf8_byte_length: 5,
 }
 
 $test::{
-  type: 'utf8_byte_length: 5',
+  type: utf8_byte_length_with_single_value,
   should_accept_as_valid: [
     '12345',
     "12345",
@@ -21,12 +21,12 @@ $test::{
 }
 
 type::{
-  name: 'utf8_byte_length: range::[5, 10]',
+  name: utf8_byte_length_with_range,
   utf8_byte_length: range::[5, 10],
 }
 
 $test::{
-  type: 'utf8_byte_length: range::[5, 10]',
+  type: utf8_byte_length_with_range,
   should_accept_as_valid:[
     '12345',
     "1234567890",
@@ -74,7 +74,7 @@ $test::{
 }
 
 $test::{
-  description: "utf8_byte_length range must not be non-empty",
+  description: "utf8_byte_length range must be satisfiable",
   isl_for_isl_can_validate: false,
   invalid_types:[
     { utf8_byte_length: range::[2, 1] },

--- a/ion_schema_2_0/constraints/valid_values-ranges.isl
+++ b/ion_schema_2_0/constraints/valid_values-ranges.isl
@@ -372,7 +372,7 @@ $test::{
 }
 
 $test::{
-  description: "valid_values ranges must not be non-empty",
+  description: "valid_values ranges must be satisfiable",
   isl_for_isl_can_validate: false,
   invalid_types:[
     { valid_values: range::[ 1, 0 ] },


### PR DESCRIPTION
*Issue #, if available:*

fixes #36
fixes #34

*Description of changes:*

* Gets rid of all the test type names that were the type definition.
* Replaces all of the "must not be non-empty" (which really should have been "must be non-empty") to be "must be satisfiable" to better convey the intent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
